### PR TITLE
fix: correct marketplace.json source field format

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,10 @@
   "plugins": [
     {
       "name": "mountaineering-skills",
-      "source": ".",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/dreamiurg/claude-mountaineering-skills.git"
+      },
       "description": "Automated mountain route research combining PeakBagger data, weather forecasts, avalanche conditions, and trip reports into comprehensive beta documents",
       "version": "1.1.0"
     }


### PR DESCRIPTION
## Summary
- Fixed the `source` field in `.claude-plugin/marketplace.json` to use the correct object structure
- Changed from `"source": "."` to proper format with `source: "url"` and GitHub repository URL
- Matches the expected marketplace plugin schema format used by superpowers-marketplace

## Test plan
- [ ] Verify the marketplace.json file validates correctly
- [ ] Test that `/plugin marketplace add dreamiurg/claude-mountaineering-skills` works without schema errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)