### PR TITLE
fix: correct plugin.json author and skills path format

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,10 @@
   "name": "mountaineering-skills",
   "version": "1.1.1",
   "description": "Automated mountain route research combining PeakBagger data, weather forecasts, avalanche conditions, and trip reports into comprehensive beta documents",
-  "author": "dreamiurg",
+  "author": {
+    "name": "dreamiurg",
+    "email": "dreamiurg@users.noreply.github.com"
+  },
   "homepage": "https://github.com/dreamiurg/claude-mountaineering-skills",
   "repository": "https://github.com/dreamiurg/claude-mountaineering-skills",
   "license": "MIT",
@@ -19,6 +22,6 @@
     "peakbagger"
   ],
   "skills": [
-    "route-researcher"
+    "./skills/route-researcher"
   ]
 }


### PR DESCRIPTION
## Summary
- Fixed the `author` field from a string to an object with `name` and `email` properties
- Updated the skills path from `"route-researcher"` to `"./skills/route-researcher"`
- Both changes required to pass validation when installing the plugin from the marketplace

## Validation Errors Fixed
1. `author: Expected object, received string`
2. `skills.0: Invalid input: must start with "./"`

## Test plan
- [ ] Verify plugin.json validates correctly
- [ ] Test that the plugin installs successfully from marketplace without validation errors
- [ ] Confirm the route-researcher skill loads properly after installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)