### PR TITLE
fix: configure semantic-release to use deploy key for branch protection bypass

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          persist-credentials: false
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- Updated release workflow to use deploy key instead of default GITHUB_TOKEN
- Allows semantic-release to push version bumps and tags to protected main branch
- Resolves GH013 repository rule violation errors

## Changes
- Replaced `persist-credentials: false` with `ssh-key: ${{ secrets.DEPLOY_KEY }}` in checkout step
- Deploy key has been added to repository and configured in ruleset bypass list

## Test plan
- [ ] Merge this PR
- [ ] Verify semantic-release workflow runs successfully on next push to main
- [ ] Confirm version bump commit and tags are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)