### PR TITLE
fix: use SSH remote for semantic-release git operations

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/dreamiurg/claude-mountaineering-skills.git"
+    "url": "git@github.com:dreamiurg/claude-mountaineering-skills.git"
   },
   "keywords": ["claude-code", "mountaineering", "climbing"],
   "author": "dreamiurg",


### PR DESCRIPTION
## Summary
- Changed repository URL from HTTPS to SSH format in package.json
- Ensures semantic-release uses the deploy key for git push operations
- Resolves continued GH013 repository rule violation errors

## Root Cause
The previous fix configured the checkout action to use the deploy key, but semantic-release's `@semantic-release/git` plugin was still using HTTPS to push because it reads the repository URL from package.json.

## Changes
- Updated `package.json` repository URL from `https://github.com/dreamiurg/claude-mountaineering-skills.git` to `git@github.com:dreamiurg/claude-mountaineering-skills.git`
- This ensures all git operations use SSH and the deploy key

## Test plan
- [ ] Merge this PR
- [ ] Verify semantic-release workflow runs successfully
- [ ] Confirm version bump commit and tags are pushed to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)