### PR TITLE
docs: simplify main README and reorganize documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,21 +48,9 @@ Claude will automatically invoke the route-researcher skill and generate a compr
 
 ### Generated Output
 
-Reports are created as Markdown files in your current working directory:
+Reports are created as Markdown files in your current working directory with comprehensive route information, current conditions, trip reports, and safety disclaimers.
 
-```
-2025-10-20-mount-baker.md
-```
-
-Each report includes:
-- Summit information (elevation, coordinates, location)
-- Route description (approach, standard route, crux)
-- Current conditions (weather, avalanche, daylight)
-- Recent trip reports with links
-- Access and permit information
-- Explicit documentation of information gaps
-
-See [examples](skills/route-researcher/examples/) for sample outputs.
+**Example:** See [Granite Mountain (Snoqualmie) route beta](skills/route-researcher/examples/2025-10-21-granite-mountain-snoqualmie.md) for a sample report.
 
 ## Features
 
@@ -91,51 +79,7 @@ If data sources are unavailable:
 
 ## Python Tools
 
-The plugin includes Python utilities for enhanced functionality:
-
-- `cloudscrape.py` - Bypasses Cloudflare protection for PeakBagger, SummitPost
-- `fetch_weather.py` - Mountain weather forecasts (in development)
-- `fetch_avalanche.py` - NWAC avalanche data (in development)
-- `calculate_daylight.py` - Sunrise/sunset calculations (in development)
-
-### Manual Installation
-
-If automatic installation failed or you don't have `uv`:
-
-```bash
-# Navigate to plugin installation
-cd ~/.claude/plugins/mountaineering-skills/skills/route-researcher/tools
-
-# Install dependencies with uv
-uv sync
-
-# Or with pip
-pip install -r requirements.txt
-```
-
-The skill will work without these tools, falling back to available data sources.
-
-## Troubleshooting
-
-### Hook Installation Failed
-
-If you see "post-install hook failed":
-
-1. Check if `uv` is installed: `uv --version`
-2. Try manual installation (see above)
-3. The skill will still work, just without some Python tools
-
-### Cloudflare Blocking Requests
-
-The `cloudscrape.py` tool handles Cloudflare protection, but may occasionally fail:
-
-- Skill automatically falls back to available sources
-- Check "Information Gaps" section in generated reports
-- Use manual verification links provided
-
-### No Route Beta Generated
-
-Ensure you're in a directory where you have write permissions. Reports are created in your current working directory, not in the plugin installation.
+The plugin includes Python utilities for enhanced data gathering (weather forecasts, avalanche conditions, daylight calculations). See [skills/route-researcher/tools/README.md](skills/route-researcher/tools/README.md) for details on available tools, manual installation, and troubleshooting.
 
 ## Updates
 

--- a/skills/route-researcher/tools/README.md
+++ b/skills/route-researcher/tools/README.md
@@ -235,6 +235,45 @@ This creates a virtual environment and installs all dependencies.
 **Python Version:**
 Python 3.11+ (specified in `.python-version`)
 
+### Manual Installation
+
+If the plugin's automatic installation failed or you don't have `uv` installed:
+
+```bash
+# Navigate to plugin installation directory
+cd ~/.claude/plugins/mountaineering-skills/skills/route-researcher/tools
+
+# Install dependencies with uv
+uv sync
+
+# Or with pip
+pip install -r requirements.txt
+```
+
+The skill will work without these tools, gracefully falling back to available data sources.
+
+### Common Issues
+
+**Hook Installation Failed**
+
+If you see "post-install hook failed":
+
+1. Check if `uv` is installed: `uv --version`
+2. Try manual installation (see above)
+3. The skill will still work, just without some Python tools
+
+**Cloudflare Blocking Requests**
+
+The `cloudscrape.py` tool handles Cloudflare protection, but may occasionally fail:
+
+- Skill automatically falls back to available sources
+- Check "Information Gaps" section in generated reports
+- Use manual verification links provided
+
+**No Route Beta Generated**
+
+Ensure you're in a directory where you have write permissions. Reports are created in your current working directory, not in the plugin installation directory.
+
 ## Development
 
 ### Adding a New Tool


### PR DESCRIPTION
## Summary

- Simplified main README.md by moving detailed technical information to skills/route-researcher/tools/README.md
- Added link to Granite Mountain example report
- Main README now provides concise overview with links to detailed documentation

## Changes

### Main README.md
- Removed verbose bullet list of report contents, replaced with concise description
- Added direct link to Granite Mountain example report
- Removed Python tools details, manual installation, and troubleshooting sections
- Added reference link to tools/README.md for technical details

### skills/route-researcher/tools/README.md
- Added "Manual Installation" section
- Added "Common Issues" section with troubleshooting information

## Benefits

- Better information architecture: high-level overview in main README, technical details in appropriate subdirectory
- Improved discoverability: users can quickly find example output
- Reduced cognitive load: main README is shorter and easier to scan
- Preserved all information: technical details moved, not removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)