### PR TITLE
feat: improve route-researcher skill clarity and trip report handling

### DIFF
--- a/skills/route-researcher/assets/report-template.md
+++ b/skills/route-researcher/assets/report-template.md
@@ -34,7 +34,20 @@
 
 **Directions:** [View on Google Maps]({google_maps_link})
 
-### Route
+### Access & Permits
+
+#### Permits & Regulations
+
+{Required permits, fees, regulations}
+
+{If not found:}
+- **Note:** Permit information not confirmed. Check with local forest service or park service.
+
+#### Road Conditions
+
+{Current access notes, seasonal closures}
+
+### Route Description
 
 {Route description synthesized from multiple sources}
 
@@ -233,20 +246,6 @@ IMPORTANT PRIORITY RULES:
 - Limit to top 5-10 total across all sources
 - If no WTA reports were extracted but WTA URL exists, note this as a failure in Information Gaps}
 
-### Recent Reports (Last 1-2 Years)
-
-{These are the most recent reports for current conditions. List top 3-5 most recent reports with actual trip report content, sorted by date descending:}
-
-- **{YYYY-MM-DD}** - [{Source}: {Climber/Author Name}]({report_url}) - 📝 {word_count if PeakBagger}{, 📍 GPX if available}
-- **{YYYY-MM-DD}** - [{Source}: {Climber/Author Name}]({report_url}) - 📝 {word_count if PeakBagger}{, 📍 GPX if available}
-
-{Format notes:
-- Only include reports from last 1-2 years
-- Sort by date (most recent first)
-- Prefix with source: [PeakBagger], [WTA], [Mountaineers]
-- Limit to top 3-5 most recent
-- If overlap with "Most Detailed Reports" section above, that's okay - recent AND detailed reports can appear in both}
-
 ### Browse All Trip Reports
 
 {Always include PeakBagger. Include other platforms only if URLs were found during data gathering (Step 2D)}
@@ -265,19 +264,6 @@ IMPORTANT PRIORITY RULES:
 
 {If very limited trip report data (<5 reports total across all sources):}
 **Note:** Limited trip reports available for this peak. Consider posting your own after your climb!
-
-## Access & Permits
-
-### Permits & Regulations
-
-{Required permits, fees, regulations}
-
-{If not found:}
-- **Note:** Permit information not confirmed. Check with local forest service or park service.
-
-### Road Conditions
-
-{Current access notes, seasonal closures}
 
 ## Information Gaps
 


### PR DESCRIPTION
## Summary

This PR refactors the route-researcher skill to improve clarity, reduce verbosity, and enhance trip report handling based on quality feedback.

## Key Changes

### Clarity & Conciseness (21% reduction: 1134 → 893 lines)

- **Simplified Step 3H (WTA/Mountaineers):** Removed brittle HTML parsing details, condensed from 88 to 30 lines
- **Consolidated Step 3I (Fetch Reports):** Merged redundant extraction categories, reduced from 141 to 28 lines  
- **Merged Phase 4B synthesis examples:** Consolidated 3 similar examples into 1 reusable pattern, reduced from 96 to 25 lines
- **Removed CRITICAL/MANDATORY overuse:** Cleaner, more professional tone

### Trip Report Quality Improvements

- **Removed word count as quality gate:** Added explicit note that a concise 50-word report with route beta is more valuable than a 500-word drive narrative
- **Increased sample size:** 3-5 reports → 10-15 reports for representative coverage
- **Emphasized diversity:** Focus on variety (sources, dates, seasons) over just recency and length
- **Clarified GPX value:** GPX tracks provide downloadable route data for users, not for AI processing

### Template & Organization

- **Moved Access & Permits** into Route section (better flow: Approach → Access → Route Description)
- **Removed "Recent Reports" section** from template (redundant with "Most Detailed Reports")

## Testing

- [ ] Skill file syntax valid
- [ ] Template structure maintained
- [ ] All essential technical details preserved

## Impact

✅ Easier to read and maintain  
✅ Better trip report selection strategy  
✅ More representative sample of conditions  
✅ Cleaner template organization

🤖 Generated with [Claude Code](https://claude.com/claude-code)