### PR TITLE
feat: automate CHANGELOG to README synchronization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ logs/
 
 # Worktrees
 .worktrees/
+
+# Documentation (internal planning)
+docs/

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -13,12 +13,16 @@
     ["@semantic-release/exec", {
       "prepareCmd": "node scripts/update-versions.js ${nextRelease.version}"
     }],
+    ["@semantic-release/exec", {
+      "prepareCmd": "node scripts/sync-changelog-to-readme.js"
+    }],
     ["@semantic-release/git", {
       "assets": [
         ".claude-plugin/plugin.json",
         ".claude-plugin/marketplace.json",
         "skills/route-researcher/SKILL.md",
         "CHANGELOG.md",
+        "README.md",
         "package.json"
       ],
       "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"

--- a/README.md
+++ b/README.md
@@ -197,26 +197,24 @@ The skill aggregates information from multiple specialized mountaineering websit
 
 ## Recent Updates
 
-**v3.3.0** (Nov 6, 2025)
-- Added example route beta reports for Mount Adams and Wolf Peak
+<!-- recent-updates:start -->
+### v3.4.0 (2025-11-07)
+- add automated report review and validation
 
-**v3.2.0** (Oct 24, 2025)
-- Expanded geographic scope from Pacific Northwest to North America
+### v3.3.0 (2025-11-06)
+- add example route beta reports for Mount Adams and Wolf Peak
 
-**v3.1.0** (Oct 24, 2025)
-- Upgraded peakbagger-cli to v1.7.0 with restructured skill workflow
+### v3.2.0 (2025-10-24)
+- expand geographic scope from Pacific Northwest to North America
 
-**v3.0.0** (Oct 23, 2025)
-- Major update with ascent analysis capabilities
-- Temporal pattern analysis and GPX track availability
-- Enhanced trip report discovery
+### v3.1.0 (2025-10-24)
+- upgrade peakbagger-cli to v1.7.0 and restructure skill workflow
 
-**v2.0.0** (Oct 21, 2025)
-- Integrated peakbagger-cli v1.0.0 with new resource-action command pattern
-- Optimized Phase 2 data gathering with parallel execution (3-4x speedup)
-- Added commit and PR templates with Conventional Commits
+### v3.0.0 (2025-10-23)
+- upgrade peakbagger-cli to v1.4.0 with ascent analysis capabilities
 
-See [CHANGELOG.md](CHANGELOG.md) for complete version history.
+[View complete changelog →](./CHANGELOG.md)
+<!-- recent-updates:end -->
 
 ---
 

--- a/scripts/sync-changelog-to-readme.js
+++ b/scripts/sync-changelog-to-readme.js
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const CHANGELOG_PATH = path.join(__dirname, '..', 'CHANGELOG.md');
+const README_PATH = path.join(__dirname, '..', 'README.md');
+const START_MARKER = '<!-- recent-updates:start -->';
+const END_MARKER = '<!-- recent-updates:end -->';
+const MAX_RELEASES = 5;
+
+function parseChangelog(changelogContent) {
+  const releases = [];
+
+  // Match release headers: ## [version](url) (date)
+  const releaseRegex = /## \[(\d+\.\d+\.\d+)\]\([^)]+\) \((\d{4}-\d{2}-\d{2})\)/g;
+  const matches = [...changelogContent.matchAll(releaseRegex)];
+
+  for (let i = 0; i < matches.length; i++) {
+    const match = matches[i];
+    const version = match[1];
+    const date = match[2];
+    const startIndex = match.index + match[0].length;
+    const endIndex = i < matches.length - 1 ? matches[i + 1].index : changelogContent.length;
+
+    const releaseContent = changelogContent.substring(startIndex, endIndex);
+
+    // Extract features and fixes
+    const features = extractBulletPoints(releaseContent, '### Features');
+    const fixes = extractBulletPoints(releaseContent, '### Bug Fixes');
+
+    // Combine all highlights
+    const highlights = [...features, ...fixes];
+
+    if (highlights.length > 0) {
+      releases.push({ version, date, highlights });
+    }
+  }
+
+  return releases.slice(0, MAX_RELEASES);
+}
+
+function extractBulletPoints(content, sectionHeader) {
+  const sectionIndex = content.indexOf(sectionHeader);
+  if (sectionIndex === -1) return [];
+
+  const afterSection = content.substring(sectionIndex + sectionHeader.length);
+  const nextSectionIndex = afterSection.search(/###\s/);
+  const sectionContent = nextSectionIndex === -1
+    ? afterSection
+    : afterSection.substring(0, nextSectionIndex);
+
+  // Extract bullet points and clean them
+  const bulletRegex = /^\* (.+)$/gm;
+  const bullets = [...sectionContent.matchAll(bulletRegex)];
+
+  return bullets.map(match => {
+    let text = match[1];
+    // Remove PR links like ([#123](...))
+    text = text.replace(/\s*\(\[#\d+\]\([^)]+\)\)/g, '');
+    // Remove commit hashes like ([abc1234](...))
+    text = text.replace(/\s*\(\[[a-f0-9]+\]\([^)]+\)\)/g, '');
+    return text.trim();
+  });
+}
+
+function generateSimplifiedFormat(releases) {
+  let output = '\n';
+
+  for (const release of releases) {
+    output += `### v${release.version} (${release.date})\n`;
+    for (const highlight of release.highlights) {
+      output += `- ${highlight}\n`;
+    }
+    output += '\n';
+  }
+
+  output += '[View complete changelog →](./CHANGELOG.md)\n';
+  return output;
+}
+
+function updateReadme(readmeContent, updatedSection) {
+  const startIndex = readmeContent.indexOf(START_MARKER);
+  const endIndex = readmeContent.indexOf(END_MARKER);
+
+  if (startIndex === -1 && endIndex === -1) {
+    console.log('→ No recent-updates markers found in README.md, skipping');
+    return null;
+  }
+
+  if (startIndex === -1 || endIndex === -1) {
+    console.error('✗ Error: Incomplete markers in README.md');
+    console.error(`  Found start marker: ${startIndex !== -1}`);
+    console.error(`  Found end marker: ${endIndex !== -1}`);
+    process.exit(1);
+  }
+
+  if (startIndex >= endIndex) {
+    console.error('✗ Error: End marker appears before start marker');
+    process.exit(1);
+  }
+
+  const before = readmeContent.substring(0, startIndex + START_MARKER.length);
+  const after = readmeContent.substring(endIndex);
+
+  return before + updatedSection + after;
+}
+
+function main() {
+  // Check if README exists
+  if (!fs.existsSync(README_PATH)) {
+    console.error('✗ Error: README.md not found');
+    process.exit(1);
+  }
+
+  // Check if CHANGELOG exists
+  if (!fs.existsSync(CHANGELOG_PATH)) {
+    console.log('→ CHANGELOG.md not found, skipping');
+    process.exit(0);
+  }
+
+  // Read files
+  const changelogContent = fs.readFileSync(CHANGELOG_PATH, 'utf8');
+  const readmeContent = fs.readFileSync(README_PATH, 'utf8');
+
+  // Parse changelog
+  let releases;
+  try {
+    releases = parseChangelog(changelogContent);
+  } catch (error) {
+    console.error('✗ Error: Failed to parse CHANGELOG.md');
+    console.error(error.message);
+    process.exit(1);
+  }
+
+  if (releases.length === 0) {
+    console.log('→ No releases found in CHANGELOG.md, skipping');
+    process.exit(0);
+  }
+
+  console.log(`Syncing last ${releases.length} releases from CHANGELOG.md to README.md`);
+
+  // Generate simplified format
+  const updatedSection = generateSimplifiedFormat(releases);
+
+  // Update README
+  const updatedReadme = updateReadme(readmeContent, updatedSection);
+
+  if (updatedReadme === null) {
+    process.exit(0);
+  }
+
+  // Write updated README
+  try {
+    fs.writeFileSync(README_PATH, updatedReadme);
+    console.log(`✓ README.md updated with ${releases.length} releases`);
+  } catch (error) {
+    console.error('✗ Error: Failed to write README.md');
+    console.error(error.message);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

Automate README updates during releases by syncing the last 5 releases from CHANGELOG.md to README.md's Recent Updates section.

## Changes

- Add `scripts/sync-changelog-to-readme.js` to parse CHANGELOG.md and update README.md between HTML comment markers
- Configure semantic-release to run script in prepare phase and commit README.md changes
- Add HTML markers to README.md Recent Updates section for automated content replacement
- Add `docs/` to `.gitignore` for internal planning documents

**Format:** Simplified version, date, and highlights only. Removes PR links, commit hashes, and breaking change sections. Links to full CHANGELOG.md.

**Error Handling:** Exits gracefully if markers missing. Fails hard on incomplete markers or file errors.

## Testing

Verified script successfully parses current CHANGELOG.md and updates README.md with last 5 releases in correct format.

Co-Authored-By: Claude <noreply@anthropic.com>