### PR TITLE
feat(route-researcher): safety geodata, conditions overhaul, itinerary + Patchright fetching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,16 +31,11 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - name: Install dependencies
-        run: |
-          pip install pytest pytest-cov
-          # Install any requirements if they exist
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          # Check for requirements in skills directories
-          find . -name "requirements.txt" -not -path "*/.git/*" -exec pip install -r {} \;
-      - name: Run tests
-        run: pytest --tb=short -q
-        continue-on-error: true
+      - name: Install uv
+        run: pip install uv
+      - name: Run route-researcher tools tests
+        working-directory: skills/route-researcher/tools
+        run: uv run --group dev pytest --tb=short -q
 
   sast:
     name: SAST

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,14 @@ docs/
 .claude/
 .beads/
 .logs/
+
+# Beads / Dolt files (added by bd init)
+.dolt/
+*.db
+.beads-credential-key
+
+# bv (beads viewer) local config and caches
+.bv/
+
+# oneshot-team transient state
+.oneshot/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,96 @@
+# Agent Instructions
+
+This project uses **bd** (beads) for issue tracking. Run `bd prime` for full workflow context.
+
+> **Architecture in one line:** Issues live in a local Dolt database
+> (`.beads/dolt/`); cross-machine sync uses `bd dolt push/pull` (a
+> git-compatible protocol), stored under `refs/dolt/data` on your git
+> remote — separate from `refs/heads/*` where your code lives.
+> `.beads/issues.jsonl` is a passive export, not the wire protocol.
+>
+> See [SYNC_CONCEPTS.md](https://github.com/gastownhall/beads/blob/main/docs/SYNC_CONCEPTS.md)
+> for the one-screen overview and anti-patterns (don't treat JSONL as the
+> source of truth; don't `bd import` during normal operation; don't
+> reach for third-party Dolt hosting before trying the default).
+
+## Quick Reference
+
+```bash
+bd ready              # Find available work
+bd show <id>          # View issue details
+bd update <id> --claim  # Claim work atomically
+bd close <id>         # Complete work
+bd dolt push          # Push beads data to remote
+```
+
+## Non-Interactive Shell Commands
+
+**ALWAYS use non-interactive flags** with file operations to avoid hanging on confirmation prompts.
+
+Shell commands like `cp`, `mv`, and `rm` may be aliased to include `-i` (interactive) mode on some systems, causing the agent to hang indefinitely waiting for y/n input.
+
+**Use these forms instead:**
+```bash
+# Force overwrite without prompting
+cp -f source dest           # NOT: cp source dest
+mv -f source dest           # NOT: mv source dest
+rm -f file                  # NOT: rm file
+
+# For recursive operations
+rm -rf directory            # NOT: rm -r directory
+cp -rf source dest          # NOT: cp -r source dest
+```
+
+**Other commands that may prompt:**
+- `scp` - use `-o BatchMode=yes` for non-interactive
+- `ssh` - use `-o BatchMode=yes` to fail instead of prompting
+- `apt-get` - use `-y` flag
+- `brew` - use `HOMEBREW_NO_AUTO_UPDATE=1` env var
+
+<!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:7510c1e2 -->
+## Beads Issue Tracker
+
+This project uses **bd (beads)** for issue tracking. Run `bd prime` to see full workflow context and commands.
+
+### Quick Reference
+
+```bash
+bd ready              # Find available work
+bd show <id>          # View issue details
+bd update <id> --claim  # Claim work
+bd close <id>         # Complete work
+```
+
+### Rules
+
+- Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
+- Run `bd prime` for detailed command reference and session close protocol
+- Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
+
+**Architecture in one line:** issues live in a local Dolt DB; sync uses `refs/dolt/data` on your git remote; `.beads/issues.jsonl` is a passive export. See https://github.com/gastownhall/beads/blob/main/docs/SYNC_CONCEPTS.md for details and anti-patterns.
+
+## Session Completion
+
+**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+
+**MANDATORY WORKFLOW:**
+
+1. **File issues for remaining work** - Create issues for anything that needs follow-up
+2. **Run quality gates** (if code changed) - Tests, linters, builds
+3. **Update issue status** - Close finished work, update in-progress items
+4. **PUSH TO REMOTE** - This is MANDATORY:
+   ```bash
+   git pull --rebase
+   git push
+   git status  # MUST show "up to date with origin"
+   ```
+5. **Clean up** - Clear stashes, prune remote branches
+6. **Verify** - All changes committed AND pushed
+7. **Hand off** - Provide context for next session
+
+**CRITICAL RULES:**
+- Work is NOT complete until `git push` succeeds
+- NEVER stop before pushing - that leaves work stranded locally
+- NEVER say "ready to push when you are" - YOU must push
+- If push fails, resolve and retry until it succeeds
+<!-- END BEADS INTEGRATION -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,49 @@
 - This project uses CI/CD that is ran on GitHub Actions. When pull requests are merged into the default branch, that CI/CD would create a new release and update a few files. It's vital to always pull the latest default branch before starting working on the new changes.
+
+<!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:7510c1e2 -->
+## Beads Issue Tracker
+
+This project uses **bd (beads)** for issue tracking. Run `bd prime` to see full workflow context and commands.
+
+### Quick Reference
+
+```bash
+bd ready              # Find available work
+bd show <id>          # View issue details
+bd update <id> --claim  # Claim work
+bd close <id>         # Complete work
+```
+
+### Rules
+
+- Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
+- Run `bd prime` for detailed command reference and session close protocol
+- Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
+
+**Architecture in one line:** issues live in a local Dolt DB; sync uses `refs/dolt/data` on your git remote; `.beads/issues.jsonl` is a passive export. See https://github.com/gastownhall/beads/blob/main/docs/SYNC_CONCEPTS.md for details and anti-patterns.
+
+## Session Completion
+
+**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+
+**MANDATORY WORKFLOW:**
+
+1. **File issues for remaining work** - Create issues for anything that needs follow-up
+2. **Run quality gates** (if code changed) - Tests, linters, builds
+3. **Update issue status** - Close finished work, update in-progress items
+4. **PUSH TO REMOTE** - This is MANDATORY:
+   ```bash
+   git pull --rebase
+   git push
+   git status  # MUST show "up to date with origin"
+   ```
+5. **Clean up** - Clear stashes, prune remote branches
+6. **Verify** - All changes committed AND pushed
+7. **Hand off** - Provide context for next session
+
+**CRITICAL RULES:**
+- Work is NOT complete until `git push` succeeds
+- NEVER stop before pushing - that leaves work stranded locally
+- NEVER say "ready to push when you are" - YOU must push
+- If push fails, resolve and retry until it succeeds
+<!-- END BEADS INTEGRATION -->

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ If you previously installed the plugin as `mountaineering-skills`, reinstall wit
 
 ## Dependencies
 
-- [peakbagger-cli](https://github.com/dreamiurg/peakbagger-cli) v1.7.0 - peak data and trip reports
+- [peakbagger-cli](https://github.com/dreamiurg/peakbagger-cli) >= v1.10.0 - peak data and trip reports
 - [Python tools](skills/route-researcher/tools/README.md) - weather, avalanche, and daylight calculations
 
 ---

--- a/commands/conditions.md
+++ b/commands/conditions.md
@@ -14,7 +14,7 @@ If the user provided a peak name as an argument (e.g., `/mountaineering:conditio
 1. **Search PeakBagger** for the peak:
 
    ```bash
-   uvx --from git+https://github.com/dreamiurg/peakbagger-cli.git@v1.7.0 peakbagger peak search "{peak_name}" --format json
+   uvx --from "peakbagger-cli>=1.10.0" peakbagger peak search "{peak_name}" --format json
    ```
 
 2. **Handle results:**
@@ -30,7 +30,7 @@ If the user provided a peak name as an argument (e.g., `/mountaineering:conditio
 Fetch peak coordinates and elevation:
 
 ```bash
-uvx --from git+https://github.com/dreamiurg/peakbagger-cli.git@v1.7.0 peakbagger peak show {peak_id} --format json
+uvx --from "peakbagger-cli>=1.10.0" peakbagger peak show {peak_id} --format json
 ```
 
 Extract: `latitude`, `longitude`, `elevation_m` (elevation in meters), `peak_name`.

--- a/commands/conditions.md
+++ b/commands/conditions.md
@@ -14,7 +14,7 @@ If the user provided a peak name as an argument (e.g., `/mountaineering:conditio
 1. **Search PeakBagger** for the peak:
 
    ```bash
-   uvx --from "peakbagger-cli>=1.10.0" peakbagger peak search "{peak_name}" --format json
+   uvx --from "git+https://github.com/dreamiurg/peakbagger-cli.git@v1.10.0" peakbagger peak search "{peak_name}" --format json
    ```
 
 2. **Handle results:**
@@ -30,7 +30,7 @@ If the user provided a peak name as an argument (e.g., `/mountaineering:conditio
 Fetch peak coordinates and elevation:
 
 ```bash
-uvx --from "peakbagger-cli>=1.10.0" peakbagger peak show {peak_id} --format json
+uvx --from "git+https://github.com/dreamiurg/peakbagger-cli.git@v1.10.0" peakbagger peak show {peak_id} --format json
 ```
 
 Extract: `latitude`, `longitude`, `elevation_m` (elevation in meters), `peak_name`.
@@ -45,6 +45,11 @@ cd ${CLAUDE_PLUGIN_ROOT}/skills/route-researcher/tools && uv run python fetch_co
   --elevation {elevation_m} \
   --peak-name "{peak_name}" \
   --peak-id {peak_id}
+  # Optional enrichment flags:
+  # --trailhead "lat,lon"          multi-county path sampling (trailhead→summit)
+  # --distance-mi N --gain-ft N    enables time_estimates
+  # --start-time HH:MM             enables itinerary (requires distance+gain)
+  # --waypoint "lat,lon" ...       enables bearings (2+ waypoints)
 ```
 
 This returns JSON with `weather`, `air_quality`, `daylight`, `avalanche`, `peakbagger`, `counties`, `nearest_hospital`, `ranger_station`, `campgrounds`, and (when `--distance-mi`/`--gain-ft` provided) `time_estimates` sections.
@@ -70,5 +75,7 @@ Format the conditions data for the user. Include:
 9. **Emergency contacts:** Nearest hospital from `nearest_hospital.hospitals[]` (name, distance, phone); nearest ranger station from `ranger_station.stations[]` + `admin_district` if on NF land; note OSM data may be incomplete in remote areas
 10. **Campgrounds near trailhead:** From `campgrounds.campgrounds[]` — name, distance, type; note backcountry/high camps not included
 11. **Time estimates** (if present): roped (`time_estimates.roped_hr`), unroped (`time_estimates.unroped_hr`), fast/moderate/leisurely — only shown when tool was called with `--distance-mi`/`--gain-ft`
+12. **Itinerary** (if present): start time, summit ETA, turnaround-by, return ETA, total car-to-car hours (`itinerary.total_hr`); if `itinerary.after_dark` is true, surface as a prominent safety warning — only present when `--start-time`, `--distance-mi`, and `--gain-ft` were all provided
+13. **Navigation bearings** (if present): per-segment bearing (degrees true north), distance, and cumulative distance; total route distance — only present when 2 or more `--waypoint` args were provided
 
 Keep the output concise and scannable. Use tables for the weather forecast and twilight.

--- a/commands/conditions.md
+++ b/commands/conditions.md
@@ -47,7 +47,7 @@ cd ${CLAUDE_PLUGIN_ROOT}/skills/route-researcher/tools && uv run python fetch_co
   --peak-id {peak_id}
 ```
 
-This returns JSON with `weather`, `air_quality`, `daylight`, `avalanche`, and `peakbagger` sections.
+This returns JSON with `weather`, `air_quality`, `daylight`, `avalanche`, `peakbagger`, `counties`, `nearest_hospital`, `ranger_station`, `campgrounds`, and (when `--distance-mi`/`--gain-ft` provided) `time_estimates` sections.
 
 **If the script fails:** Note the failure and provide manual check links:
 
@@ -60,11 +60,15 @@ This returns JSON with `weather`, `air_quality`, `daylight`, `avalanche`, and `p
 Format the conditions data for the user. Include:
 
 1. **Peak summary:** Name, elevation, coordinates
-2. **Weather forecast:** 7-day table with date, conditions, high/low temps, precipitation, wind, freezing level
-3. **Freezing level alert:** If any forecasted freezing level is within 2000 ft of summit elevation, warn about potential ice/snow at summit
+2. **Weather forecast:** 7-day table with date, conditions, high/low temps, precipitation, wind, freezing level; include **Snow Line** column from `weather.forecast[].snow_line_note` + ⚠️ when `near_summit=true`
+3. **Freezing level / snow-line alert:** If any day has `near_summit=true` (freezing level within 2000 ft of summit), call it out prominently
 4. **Air quality:** AQI rating. Only highlight if AQI > 50 (anything above "Good")
-5. **Daylight:** Sunrise, sunset, civil twilight, day length for the next day
+5. **Daylight:** Full twilight table — astronomical dawn, nautical dawn, civil twilight, sunrise, sunset, civil dusk, nautical dusk, astronomical dusk; show "— (white night)" for null values; include day length
 6. **Avalanche:** Region, danger rating if available, link to full forecast
 7. **PeakBagger stats:** Recent ascent count and patterns (if available)
+8. **Counties traversed:** From `counties.counties[]` — list `county_name`, `state_name`; note if unavailable
+9. **Emergency contacts:** Nearest hospital from `nearest_hospital.hospitals[]` (name, distance, phone); nearest ranger station from `ranger_station.stations[]` + `admin_district` if on NF land; note OSM data may be incomplete in remote areas
+10. **Campgrounds near trailhead:** From `campgrounds.campgrounds[]` — name, distance, type; note backcountry/high camps not included
+11. **Time estimates** (if present): roped (`time_estimates.roped_hr`), unroped (`time_estimates.unroped_hr`), fast/moderate/leisurely — only shown when tool was called with `--distance-mi`/`--gain-ft`
 
-Keep the output concise and scannable. Use tables for the weather forecast.
+Keep the output concise and scannable. Use tables for the weather forecast and twilight.

--- a/commands/trip-reports.md
+++ b/commands/trip-reports.md
@@ -14,7 +14,7 @@ If the user provided a peak name as an argument (e.g., `/mountaineering:trip-rep
 1. **Search PeakBagger** for the peak:
 
    ```bash
-   uvx --from git+https://github.com/dreamiurg/peakbagger-cli.git@v1.7.0 peakbagger peak search "{peak_name}" --format json
+   uvx --from "peakbagger-cli>=1.10.0" peakbagger peak search "{peak_name}" --format json
    ```
 
 2. **Handle results:**
@@ -30,7 +30,7 @@ If the user provided a peak name as an argument (e.g., `/mountaineering:trip-rep
 Fetch peak coordinates and basic info:
 
 ```bash
-uvx --from git+https://github.com/dreamiurg/peakbagger-cli.git@v1.7.0 peakbagger peak show {peak_id} --format json
+uvx --from "peakbagger-cli>=1.10.0" peakbagger peak show {peak_id} --format json
 ```
 
 Extract: `peak_name`, `elevation_ft`, `location`, `latitude`, `longitude`.
@@ -44,13 +44,13 @@ Run these two sources **in parallel**:
 1. Get recent ascents with trip reports:
 
    ```bash
-   uvx --from git+https://github.com/dreamiurg/peakbagger-cli.git@v1.7.0 peakbagger peak ascents {peak_id} --with-tr --within 2y --limit 20 --format json
+   uvx --from "peakbagger-cli>=1.10.0" peakbagger peak ascents {peak_id} --with-tr --within 2y --limit 20 --format json
    ```
 
 2. For the **10 most recent** ascents that have trip reports (word_count > 0), fetch full content:
 
    ```bash
-   uvx --from git+https://github.com/dreamiurg/peakbagger-cli.git@v1.7.0 peakbagger ascent show {ascent_id} --format json
+   uvx --from "peakbagger-cli>=1.10.0" peakbagger ascent show {ascent_id} --format json
    ```
 
 3. From each report extract: date, author, route taken, conditions described, gear mentioned, hazards noted, key observations.

--- a/commands/trip-reports.md
+++ b/commands/trip-reports.md
@@ -14,7 +14,7 @@ If the user provided a peak name as an argument (e.g., `/mountaineering:trip-rep
 1. **Search PeakBagger** for the peak:
 
    ```bash
-   uvx --from "peakbagger-cli>=1.10.0" peakbagger peak search "{peak_name}" --format json
+   uvx --from "git+https://github.com/dreamiurg/peakbagger-cli.git@v1.10.0" peakbagger peak search "{peak_name}" --format json
    ```
 
 2. **Handle results:**
@@ -30,7 +30,7 @@ If the user provided a peak name as an argument (e.g., `/mountaineering:trip-rep
 Fetch peak coordinates and basic info:
 
 ```bash
-uvx --from "peakbagger-cli>=1.10.0" peakbagger peak show {peak_id} --format json
+uvx --from "git+https://github.com/dreamiurg/peakbagger-cli.git@v1.10.0" peakbagger peak show {peak_id} --format json
 ```
 
 Extract: `peak_name`, `elevation_ft`, `location`, `latitude`, `longitude`.
@@ -44,13 +44,13 @@ Run these two sources **in parallel**:
 1. Get recent ascents with trip reports:
 
    ```bash
-   uvx --from "peakbagger-cli>=1.10.0" peakbagger peak ascents {peak_id} --with-tr --within 2y --limit 20 --format json
+   uvx --from "git+https://github.com/dreamiurg/peakbagger-cli.git@v1.10.0" peakbagger peak ascents {peak_id} --with-tr --within 2y --limit 20 --format json
    ```
 
 2. For the **10 most recent** ascents that have trip reports (word_count > 0), fetch full content:
 
    ```bash
-   uvx --from "peakbagger-cli>=1.10.0" peakbagger ascent show {ascent_id} --format json
+   uvx --from "git+https://github.com/dreamiurg/peakbagger-cli.git@v1.10.0" peakbagger ascent show {ascent_id} --format json
    ```
 
 3. From each report extract: date, author, route taken, conditions described, gear mentioned, hazards noted, key observations.

--- a/skills/route-researcher/SKILL.md
+++ b/skills/route-researcher/SKILL.md
@@ -139,8 +139,15 @@ uv run python fetch_conditions.py \
   --coordinates "{latitude},{longitude}" \
   --elevation {elevation_m} \
   --peak-name "{peak_name}" \
-  --peak-id {peak_id}
+  --peak-id {peak_id} \
+  --trailhead "{trailhead_lat},{trailhead_lon}" \
+  --distance-mi {round_trip_distance_mi} \
+  --gain-ft {total_gain_ft} \
+  --start-time "{HH:MM}" \
+  --waypoint "{lat1},{lon1}" --waypoint "{lat2},{lon2}"
 ```
+
+Optional args: `--trailhead` enables multi-county sampling and hospital/ranger lookups from the trailhead; `--distance-mi`/`--gain-ft` enable `time_estimates`; `--start-time` (with distance + gain) enables `itinerary`; `--waypoint` (2+) enables `bearings`.
 
 This returns JSON with:
 
@@ -148,6 +155,8 @@ This returns JSON with:
 - **air_quality**: AQI ratings and any concerns
 - **daylight**: Full twilight table — `astronomical_dawn`, `nautical_dawn`, `civil_twilight` (dawn), `sunrise`, `sunset`, `civil_dusk`, `nautical_dusk`, `astronomical_dusk`; values are `null` at high latitudes when sun doesn't reach threshold (white nights); `daylight_hours`, `timezone`
 - **time_estimates**: Roped/unroped + 3-tier pacing (`roped_hr`, `unroped_hr`, `fast_hr`, `moderate_hr`, `leisurely_hr`) — only present when `--distance-mi` and `--gain-ft` CLI args are provided
+- **itinerary**: Trip schedule with safety signals (`start_time`, `summit_eta`, `turnaround_by`, `return_eta`, `total_hr`, `after_dark` bool, `dusk_cutoff`, `note`) — only present when `--start-time`, `--distance-mi`, AND `--gain-ft` are all provided; `after_dark: true` is a safety warning that must be prominently surfaced; `total_hr` is the full round-trip duration in hours
+- **bearings**: Navigation bearings between waypoints (`segments[]` with `bearing_deg`, `distance_mi`, `cumulative_distance_mi`; `total_distance_mi`) — only present when 2 or more `--waypoint "lat,lon"` args are provided
 - **avalanche**: NWAC region and URL for manual check
 - **peakbagger**: Ascent statistics and recent ascents (if peak_id provided)
 - **counties**: Counties traversed trailhead→summit (`counties[]` with `county_name`, `county_fips`, `state_name`, `state_code`); pass `--trailhead "lat,lon"` for multi-county routes
@@ -534,7 +543,9 @@ Organize all gathered and analyzed data into structured JSON:
     "nearest_hospital": {"hospitals": [{"name": "...", "distance_miles": N, "emergency": "yes|null", "phone": "..."}]},
     "ranger_station": {"stations": [{"name": "...", "distance_miles": N, "phone": null, "website": null}], "admin_district": {"district_name": "...", "forest_name": "...", "region": "..."}},
     "campgrounds": {"campgrounds": [{"name": "...", "distance_miles": N, "camp_type": "..."}], "note": "..."},
-    "time_estimates": {"roped_hr": N, "unroped_hr": N, "fast_hr": N, "moderate_hr": N, "leisurely_hr": N, "note": "..."}
+    "time_estimates": {"roped_hr": N, "unroped_hr": N, "fast_hr": N, "moderate_hr": N, "leisurely_hr": N, "note": "..."},
+    "itinerary": {"start_time": "HH:MM", "summit_eta": "HH:MM", "turnaround_by": "HH:MM", "return_eta": "HH:MM", "total_hr": N, "after_dark": false, "dusk_cutoff": "HH:MM label", "note": "..."},
+    "bearings": {"segments": [{"from": 0, "to": 1, "bearing_deg": N, "distance_mi": N, "cumulative_distance_mi": N}], "total_distance_mi": N}
   },
   "route_data": {
     // Merged from all Researcher agents
@@ -701,6 +712,8 @@ Report to user:
    - Review the report
    - Verify critical information from primary sources
    - Check current conditions before attempting route
+   - **Itinerary and navigation**: If the user wants a start-time schedule and/or compass bearings, re-run `fetch_conditions.py` with `--start-time HH:MM` (adds `itinerary` key) and/or `--waypoint lat,lon` flags (2+ waypoints add `bearings` key). Surface `after_dark: true` as a prominent safety warning.
+   - **Post-climb trip report**: After the climb, offer the trip-report template at `skills/route-researcher/assets/trip-report-template.md` as a starting point for filing a trip report.
 
 **Example completion message:**
 
@@ -809,6 +822,9 @@ See `skills/route-researcher/docs/architecture.md` for detailed execution flow a
 - **Avalanche region detection** (inline in `fetch_conditions.py`) - NWAC region and URL by coordinates
 - **New source sites** (Agent 2): northwesthikers.net, hikeoftheweek.com (Cloudflare → `--render`), oregonhikers.org (WebFetch-friendly), cascadeclimbers.com, Mountain Project
 - **Weather source ranking**: NOAA + Meteoblue are most reliable; Mountain-Forecast for multi-elevation; Windy for visual wind/precip
+- **Itinerary scheduling** (`--start-time HH:MM`): `itinerary` key adds start/summit-ETA/turnaround-by/return-ETA; `after_dark: true` means projected return exceeds nautical dusk — surface as a safety warning
+- **Navigation bearings** (`--waypoint lat,lon`, repeatable): `bearings` key adds per-segment spherical azimuth (0=N, 90=E) and cumulative distance; requires 2+ waypoints
+- **Trip-report template**: `skills/route-researcher/assets/trip-report-template.md` — a climber-facing post-climb template; offer it in Phase 7 next steps
 
 **Pending Implementation:**
 
@@ -901,4 +917,4 @@ Example: `https://www.google.com/maps/search/?api=1&query=Cascade+Pass+Trailhead
 
 ---
 
-**Skill Version:** 4.0.2 | **Last Updated:** 2026-01-30
+**Skill Version:** 4.0.3 | **Last Updated:** 2026-01-31

--- a/skills/route-researcher/SKILL.md
+++ b/skills/route-researcher/SKILL.md
@@ -149,6 +149,10 @@ This returns JSON with:
 - **daylight**: Sunrise, sunset, civil twilight
 - **avalanche**: NWAC region and URL for manual check
 - **peakbagger**: Ascent statistics and recent ascents (if peak_id provided)
+- **counties**: Counties traversed trailhead→summit (`counties[]` with `county_name`, `county_fips`, `state_name`, `state_code`); pass `--trailhead "lat,lon"` for multi-county routes
+- **nearest_hospital**: Nearest hospitals/ERs (`hospitals[]` with `name`, `distance_miles`, `emergency`, `phone`); sorted emergency-first then by distance; max 3
+- **ranger_station**: Nearest ranger stations (`stations[]` with `name`, `distance_miles`, `phone`, `website`) + optional `admin_district` (`district_name`, `forest_name`, `region`) when trailhead is on NF land
+- **campgrounds**: Established campgrounds within ~12 mi (20 km) (`campgrounds[]` with `name`, `distance_miles`, `camp_type`, `backcountry`, `operator`); backcountry/high camps are NOT included — extract those from trip reports
 - **gaps**: Any API failures noted for report
 
 **Run this in parallel with Step 3B** — include both the Bash command for fetch_conditions.py and all 3 Task calls in the same response turn to maximize parallelism.
@@ -403,7 +407,15 @@ From all synthesized data, identify:
   - Example: 5,469 ft peak with 5,000-8,000 ft freezing levels → Include alert (marginal conditions)
   - Example: 4,000 ft peak with 10,000+ ft freezing levels → Omit alert (well above summit)
 
-#### Step 4C: Identify Information Gaps
+#### Step 4C: Surface Geodata in Report
+
+Include these geodata fields in the report when available:
+
+- **Counties:** List `county_name + state_name` from `conditions.counties.counties[]` in the Overview section. If the array is empty or `error` is present, note in Information Gaps.
+- **Emergency contacts:** Populate the Emergency Contacts section from `conditions.nearest_hospital.hospitals[]` and `conditions.ranger_station` (stations + admin_district). If either is missing or has an `error` key, note in Information Gaps and direct the user to check manually.
+- **Campgrounds:** Populate the Camping section from `conditions.campgrounds.campgrounds[]`. Explicitly state that backcountry/high camps are not in this list and must be extracted from trip reports.
+
+#### Step 4D: Identify Information Gaps
 
 Explicitly document what data was **not found or unreliable:**
 
@@ -437,7 +449,11 @@ Organize all gathered and analyzed data into structured JSON:
     "air_quality": {...},
     "daylight": {...},
     "avalanche": {...},
-    "peakbagger": {...}
+    "peakbagger": {...},
+    "counties": {"counties": [{"county_name": "...", "county_fips": "...", "state_name": "...", "state_code": "..."}], ...},
+    "nearest_hospital": {"hospitals": [{"name": "...", "distance_miles": N, "emergency": "yes|null", "phone": "..."}]},
+    "ranger_station": {"stations": [{"name": "...", "distance_miles": N, "phone": null, "website": null}], "admin_district": {"district_name": "...", "forest_name": "...", "region": "..."}},
+    "campgrounds": {"campgrounds": [{"name": "...", "distance_miles": N, "camp_type": "..."}], "note": "..."}
   },
   "route_data": {
     // Merged from all Researcher agents

--- a/skills/route-researcher/SKILL.md
+++ b/skills/route-researcher/SKILL.md
@@ -144,9 +144,10 @@ uv run python fetch_conditions.py \
 
 This returns JSON with:
 
-- **weather**: 7-day forecast with temperatures, precipitation, freezing levels
+- **weather**: 7-day forecast with temperatures, precipitation, freezing levels; each day includes `snow_line_note` (human-readable framing of freezing level as snow line) and `near_summit` (bool: true when freezing level within 2000 ft of summit)
 - **air_quality**: AQI ratings and any concerns
-- **daylight**: Sunrise, sunset, civil twilight
+- **daylight**: Full twilight table — `astronomical_dawn`, `nautical_dawn`, `civil_twilight` (dawn), `sunrise`, `sunset`, `civil_dusk`, `nautical_dusk`, `astronomical_dusk`; values are `null` at high latitudes when sun doesn't reach threshold (white nights); `daylight_hours`, `timezone`
+- **time_estimates**: Roped/unroped + 3-tier pacing (`roped_hr`, `unroped_hr`, `fast_hr`, `moderate_hr`, `leisurely_hr`) — only present when `--distance-mi` and `--gain-ft` CLI args are provided
 - **avalanche**: NWAC region and URL for manual check
 - **peakbagger**: Ascent statistics and recent ascents (if peak_id provided)
 - **counties**: Counties traversed trailhead→summit (`counties[]` with `county_name`, `county_fips`, `state_name`, `state_code`); pass `--trailhead "lat,lon"` for multi-county routes
@@ -234,7 +235,7 @@ For each report fetched, extract:
 )
 ```
 
-**Agent 2: WTA + Mountaineers**
+**Agent 2: WTA + Mountaineers + Regional Sources**
 
 ```
 Task(
@@ -243,7 +244,7 @@ Task(
   prompt="""You are a route researcher gathering mountaineering data for {peak_name}.
 
 ## Your Assignment
-Research from these sources: WTA, Mountaineers.org
+Research from these sources: WTA, Mountaineers.org, northwesthikers.net, hikeoftheweek.com, Oregon Hikers Field Guide (oregonhikers.org), Cascade Climbers (cascadeclimbers.com), Mountain Project
 
 ## WTA Research
 1. Search: "{peak_name} site:wta.org"
@@ -262,6 +263,41 @@ Research from these sources: WTA, Mountaineers.org
 
 1. Search: "{peak_name} site:mountaineers.org route"
 2. Extract route beta, technical requirements, hazards
+
+## NWHikers Research (northwesthikers.net / nwhikers.net)
+
+1. Search: "{peak_name} site:nwhikers.net OR site:northwesthikers.net"
+2. Use WebFetch to extract first-person trip reports, GPS track notes, conditions
+3. If WebFetch fails, use `cloudscrape.py "{url}"` (fast path usually sufficient)
+
+## Hike of the Week (hikeoftheweek.com — REQUIRES --render)
+
+1. Search: "{peak_name} site:hikeoftheweek.com"
+2. **MUST use `--render` flag** — site is Cloudflare-protected and blocks WebFetch:
+
+   ```bash
+   uv run python {repo_root}/skills/route-researcher/tools/cloudscrape.py --render "{url}"
+   ```
+
+3. Extract: logistics, route narrative, access notes, trailhead directions
+
+## Oregon Hikers Field Guide (oregonhikers.org — Oregon objectives only)
+
+1. Search: "{peak_name} site:oregonhikers.org"
+2. Use WebFetch — site is static MediaWiki HTML, WebFetch-friendly
+3. Extract: route description, access, permits, conditions notes
+
+## Cascade Climbers (cascadeclimbers.com)
+
+1. Search: "{peak_name} site:cascadeclimbers.com"
+2. Use WebFetch; if blocked use `cloudscrape.py "{url}"`
+3. Extract: technical route beta, gear lists, trip reports, conditions
+
+## Mountain Project (for technical/rock sections)
+
+1. Search: "{peak_name} site:mountainproject.com"
+2. Use WebFetch to extract: route name, grade, gear, description, rock quality
+3. If WebFetch fails, use `cloudscrape.py "{url}"`
 
 ## Fallback
 
@@ -285,7 +321,7 @@ For each report fetched, extract:
 
 ```json
 {
-  "sources": ["WTA", "Mountaineers"],
+  "sources": ["WTA", "Mountaineers", "NWHikers", "HikeOfTheWeek", "OregonHikers", "CascadeClimbers", "MountainProject"],
   "route_info": [
     {"source": "...", "name": "...", "difficulty": "...", "description": "...", "hazards": [...]}
   ],
@@ -489,15 +525,16 @@ Organize all gathered and analyzed data into structured JSON:
   },
   "conditions": {
     // From fetch_conditions.py output
-    "weather": {...},
+    "weather": {"forecast": [{"date": "...", "snow_line_note": "...", "near_summit": bool, "freezing_level_ft": N, ...}], ...},
     "air_quality": {...},
-    "daylight": {...},
+    "daylight": {"astronomical_dawn": "...", "nautical_dawn": "...", "civil_twilight": "...", "sunrise": "...", "sunset": "...", "civil_dusk": "...", "nautical_dusk": "...", "astronomical_dusk": "...", "daylight_hours": N},
     "avalanche": {...},
     "peakbagger": {...},
     "counties": {"counties": [{"county_name": "...", "county_fips": "...", "state_name": "...", "state_code": "..."}], ...},
     "nearest_hospital": {"hospitals": [{"name": "...", "distance_miles": N, "emergency": "yes|null", "phone": "..."}]},
     "ranger_station": {"stations": [{"name": "...", "distance_miles": N, "phone": null, "website": null}], "admin_district": {"district_name": "...", "forest_name": "...", "region": "..."}},
-    "campgrounds": {"campgrounds": [{"name": "...", "distance_miles": N, "camp_type": "..."}], "note": "..."}
+    "campgrounds": {"campgrounds": [{"name": "...", "distance_miles": N, "camp_type": "..."}], "note": "..."},
+    "time_estimates": {"roped_hr": N, "unroped_hr": N, "fast_hr": N, "moderate_hr": N, "leisurely_hr": N, "note": "..."}
   },
   "route_data": {
     // Merged from all Researcher agents
@@ -735,7 +772,7 @@ The route-researcher skill uses a hybrid architecture combining Python scripts a
 **Components:**
 
 - **Python script** (`tools/fetch_conditions.py`) - Deterministic API calls for weather, air quality, daylight, avalanche, and PeakBagger data
-- **Researcher agents** (3 total) - Web research for route info and trip reports from PeakBagger+SummitPost, WTA+Mountaineers, and AllTrails
+- **Researcher agents** (3 total) - Web research for route info and trip reports from PeakBagger+SummitPost, WTA+Mountaineers+NWHikers+HikeOfTheWeek+OregonHikers+CascadeClimbers+MountainProject, and AllTrails
 - **Report Writer agent** - Generates markdown reports from aggregated data
 - **Report Reviewer agent** - Validates report quality before presentation
 
@@ -763,10 +800,15 @@ See `skills/route-researcher/docs/architecture.md` for detailed execution flow a
 - **Open-Meteo Weather API** for mountain weather forecasts (temperature, precipitation, freezing level, wind)
 - **Open-Meteo Air Quality API** for AQI forecasting (US AQI scale with conditional alerts)
 - Adaptive ascent data retrieval based on peak popularity
-- **astral Python library** for daylight calculations (sunrise, sunset, civil twilight, day length)
+- **astral Python library** for daylight calculations — full twilight table (astronomical/nautical/civil dawn + dusk, sunrise, sunset); null values for white-night dates
+- **Snow line / freezing level emphasis** — per-day `snow_line_note` and `near_summit` flag in weather output
+- **Speed/time estimates** — `time_estimates` key with roped/unroped + 3-tier pacing (when `--distance-mi` and `--gain-ft` provided)
+- **Geodata fetchers** — counties (FCC), nearest hospital/ER (OSM), ranger station + USFS admin district (OSM + ArcGIS), campgrounds (OSM)
 - **High-quality trip report identification** across PeakBagger and WTA sources
 - **WTA AJAX endpoint** for trip report extraction (`{wta_url}/@@related_tripreport_listing`)
 - **Avalanche region detection** (inline in `fetch_conditions.py`) - NWAC region and URL by coordinates
+- **New source sites** (Agent 2): northwesthikers.net, hikeoftheweek.com (Cloudflare → `--render`), oregonhikers.org (WebFetch-friendly), cascadeclimbers.com, Mountain Project
+- **Weather source ranking**: NOAA + Meteoblue are most reliable; Mountain-Forecast for multi-elevation; Windy for visual wind/precip
 
 **Pending Implementation:**
 

--- a/skills/route-researcher/SKILL.md
+++ b/skills/route-researcher/SKILL.md
@@ -53,7 +53,7 @@ Research Progress:
 2. **Search PeakBagger** using peakbagger-cli:
 
    ```bash
-   uvx --from "peakbagger-cli>=1.10.0" peakbagger peak search "{peak_name}" --format json
+   uvx --from "git+https://github.com/dreamiurg/peakbagger-cli.git@v1.10.0" peakbagger peak search "{peak_name}" --format json
    ```
 
    - Parse JSON output to extract peak matches
@@ -100,7 +100,7 @@ This phase must complete before Phase 3, as coordinates are required for weather
 Retrieve detailed peak information using the peak ID from Phase 1:
 
 ```bash
-uvx --from "peakbagger-cli>=1.10.0" peakbagger peak show {peak_id} --format json
+uvx --from "git+https://github.com/dreamiurg/peakbagger-cli.git@v1.10.0" peakbagger peak show {peak_id} --format json
 ```
 
 This returns structured JSON with:
@@ -147,7 +147,7 @@ uv run python fetch_conditions.py \
   --waypoint "{lat1},{lon1}" --waypoint "{lat2},{lon2}"
 ```
 
-Optional args: `--trailhead` enables multi-county sampling and hospital/ranger lookups from the trailhead; `--distance-mi`/`--gain-ft` enable `time_estimates`; `--start-time` (with distance + gain) enables `itinerary`; `--waypoint` (2+) enables `bearings`.
+Optional args: `--trailhead` enables multi-county path sampling (trailhead→summit); hospital/ranger lookups always run from the summit regardless; `--distance-mi`/`--gain-ft` enable `time_estimates`; `--start-time` (with distance + gain) enables `itinerary`; `--waypoint` (2+) enables `bearings`.
 
 This returns JSON with:
 
@@ -159,9 +159,9 @@ This returns JSON with:
 - **bearings**: Navigation bearings between waypoints (`segments[]` with `bearing_deg`, `distance_mi`, `cumulative_distance_mi`; `total_distance_mi`) — only present when 2 or more `--waypoint "lat,lon"` args are provided
 - **avalanche**: NWAC region and URL for manual check
 - **peakbagger**: Ascent statistics and recent ascents (if peak_id provided)
-- **counties**: Counties traversed trailhead→summit (`counties[]` with `county_name`, `county_fips`, `state_name`, `state_code`); pass `--trailhead "lat,lon"` for multi-county routes
-- **nearest_hospital**: Nearest hospitals/ERs (`hospitals[]` with `name`, `distance_miles`, `emergency`, `phone`); sorted emergency-first then by distance; max 3
-- **ranger_station**: Nearest ranger stations (`stations[]` with `name`, `distance_miles`, `phone`, `website`) + optional `admin_district` (`district_name`, `forest_name`, `region`) when trailhead is on NF land
+- **counties**: Counties traversed trailhead→summit (`counties[]` with `county_name`, `county_fips`, `state_name`, `state_code`); `sampled` bool and `sample_points` int indicate whether path sampling ran (requires `--trailhead`); without `--trailhead` only the summit county is returned
+- **nearest_hospital**: Nearest hospitals/ERs (`hospitals[]` with `name`, `distance_miles`, `emergency`, `phone` (optional — omitted when OSM has no phone tag)); sorted emergency-first then by distance; max 3
+- **ranger_station**: Nearest ranger stations (`stations[]` with `name`, `distance_miles`, `phone`, `website`) + optional `admin_district` (`district_name`, `forest_name`, `region`) when the summit coordinates intersect a USFS ranger district
 - **campgrounds**: Established campgrounds within ~12 mi (20 km) (`campgrounds[]` with `name`, `distance_miles`, `camp_type`, `backcountry`, `operator`); backcountry/high camps are NOT included — extract those from trip reports
 - **gaps**: Any API failures noted for report
 
@@ -187,14 +187,14 @@ Research from these sources: PeakBagger, SummitPost
 2. Extract route descriptions from peak page
 3. List recent ascents with trip reports:
    ```bash
-   uvx --from "peakbagger-cli>=1.10.0" peakbagger peak ascents {peak_id} --format json --with-tr --limit 20
+   uvx --from "git+https://github.com/dreamiurg/peakbagger-cli.git@v1.10.0" peakbagger peak ascents {peak_id} --format json --with-tr --limit 20
    ```
 
 4. Identify trip reports with content (word_count > 0)
 5. Fetch content for up to 5 recent trip reports using:
 
    ```bash
-   uvx --from "peakbagger-cli>=1.10.0" peakbagger ascent show {ascent_id} --format json
+   uvx --from "git+https://github.com/dreamiurg/peakbagger-cli.git@v1.10.0" peakbagger ascent show {ascent_id} --format json
    ```
 
 ## SummitPost Research
@@ -204,10 +204,10 @@ Research from these sources: PeakBagger, SummitPost
 3. If WebFetch fails, use the fetching ladder:
 
    ```bash
-   # Fast path (TLS-spoofed httpx, no browser)
+   # Fast path (httpx with browser-like headers, no browser)
    uv run python {repo_root}/skills/route-researcher/tools/cloudscrape.py "{url}"
 
-   # If the above returns empty or is blocked (Cloudflare / JS-rendered):
+   # If the above returns {"error": ...} or content is blocked/JS-rendered:
    uv run python {repo_root}/skills/route-researcher/tools/cloudscrape.py --render "{url}"
    ```
 
@@ -264,7 +264,7 @@ Research from these sources: WTA, Mountaineers.org, northwesthikers.net, hikeoft
    # Fast path first
    uv run python {repo_root}/skills/route-researcher/tools/cloudscrape.py "{trip_report_url}"
 
-   # If blocked or returns empty content:
+   # If output contains {"error": ...} or content is blocked/JS-rendered:
    uv run python {repo_root}/skills/route-researcher/tools/cloudscrape.py --render "{trip_report_url}"
    ```
 
@@ -481,15 +481,7 @@ From all synthesized data, identify:
 - **Notable Gear:** Any unusual or important gear mentioned in trip reports or beta (to be included in relevant sections, not as standalone section)
 - **Trailhead:** Name and approximate location
 - **Distance/Gain:** Round-trip distance and elevation gain (compare published vs actual trip report data)
-- **Time Estimates:** Calculate three-tier pacing based on distance and gain:
-  - **Fast pace:** Calculate based on 2+ mph and 1000+ ft/hr gain rate
-  - **Moderate pace:** Calculate based on 1.5-2 mph and 700-900 ft/hr gain rate
-  - **Leisurely pace:** Calculate based on 1-1.5 mph and 500-700 ft/hr gain rate
-  - Use the **slower** of distance-based or gain-based calculations for each tier
-  - Example: For 4 miles round-trip, 2700 ft gain:
-    - Fast: max(4mi/2mph, 2700ft/1000ft/hr) = max(2hr, 2.7hr) = ~3 hours
-    - Moderate: max(4mi/1.5mph, 2700ft/800ft/hr) = max(2.7hr, 3.4hr) = ~3-4 hours
-    - Leisurely: max(4mi/1mph, 2700ft/600ft/hr) = max(4hr, 4.5hr) = ~4-5 hours
+- **Time Estimates:** Use `conditions.time_estimates` (keys: `fast_hr`, `moderate_hr`, `leisurely_hr`, `roped_hr`, `unroped_hr`) from fetch_conditions.py output — present only when it was called with `--distance-mi` and `--gain-ft`. If `time_estimates` is absent from the conditions data, note it in Information Gaps. **To populate it:** re-invoke fetch_conditions.py with `--distance-mi {distance}` and `--gain-ft {gain}` once route distance/gain are known from Step 3B research. At the same time, add `--start-time HH:MM` to get `itinerary` and `--waypoint` args to get `bearings` — these optional outputs only activate when the args are supplied.
 - **Freezing Level Analysis:** Compare peak elevation with forecasted freezing levels:
   - **Include Freezing Level Alert if:** Any day in forecast has freezing level within 2000 ft of peak elevation
   - **Omit if:** Freezing level stays >2000 ft above peak throughout forecast (typical summer conditions)
@@ -539,12 +531,12 @@ Organize all gathered and analyzed data into structured JSON:
     "daylight": {"astronomical_dawn": "...", "nautical_dawn": "...", "civil_twilight": "...", "sunrise": "...", "sunset": "...", "civil_dusk": "...", "nautical_dusk": "...", "astronomical_dusk": "...", "daylight_hours": N},
     "avalanche": {...},
     "peakbagger": {...},
-    "counties": {"counties": [{"county_name": "...", "county_fips": "...", "state_name": "...", "state_code": "..."}], ...},
-    "nearest_hospital": {"hospitals": [{"name": "...", "distance_miles": N, "emergency": "yes|null", "phone": "..."}]},
+    "counties": {"counties": [{"county_name": "...", "county_fips": "...", "state_name": "...", "state_code": "..."}], "sampled": bool, "sample_points": N},  // sampled + sample_points only present when --trailhead was given
+    "nearest_hospital": {"hospitals": [{"name": "...", "distance_miles": N, "emergency": "yes|null", "phone": "..." /* optional */}]},
     "ranger_station": {"stations": [{"name": "...", "distance_miles": N, "phone": null, "website": null}], "admin_district": {"district_name": "...", "forest_name": "...", "region": "..."}},
     "campgrounds": {"campgrounds": [{"name": "...", "distance_miles": N, "camp_type": "..."}], "note": "..."},
     "time_estimates": {"roped_hr": N, "unroped_hr": N, "fast_hr": N, "moderate_hr": N, "leisurely_hr": N, "note": "..."},
-    "itinerary": {"start_time": "HH:MM", "summit_eta": "HH:MM", "turnaround_by": "HH:MM", "return_eta": "HH:MM", "total_hr": N, "after_dark": false, "dusk_cutoff": "HH:MM label", "note": "..."},
+    "itinerary": {"start_time": "HH:MM", "summit_eta": "HH:MM", "turnaround_by": "HH:MM", "return_eta": "HH:MM", "total_hr": N, "after_dark": false, "dusk_cutoff": "9:15 PM" /* 12-hr AM/PM format, unlike other time fields */, "note": "..."},
     "bearings": {"segments": [{"from": 0, "to": 1, "bearing_deg": N, "distance_mi": N, "cumulative_distance_mi": N}], "total_distance_mi": N}
   },
   "route_data": {
@@ -558,7 +550,6 @@ Organize all gathered and analyzed data into structured JSON:
     "difficulty": "{rating}",
     "crux": "{description}",
     "hazards": [...],
-    "time_estimates": {...},
     "access": {...}
   },
   "gaps": [...]
@@ -752,7 +743,7 @@ Throughout execution, follow these error handling guidelines:
 ### WebFetch/WebSearch Issues
 
 - **Fetching ladder:** WebFetch first → `cloudscrape.py "{url}"` (fast httpx, no browser) → `cloudscrape.py --render "{url}"` (Patchright stealth browser, for JS-rendered or Cloudflare-protected pages)
-- **When to use `--render`:** hikeoftheweek.com and any site where the default path returns empty or blocked content
+- **When to use `--render`:** hikeoftheweek.com and any site where the default path returns `{"error": ...}` on stdout or where content is blocked/JS-rendered
 - **Graceful degradation:** Missing one source shouldn't stop entire research; cloudscrape.py exits 0 on failure
 - **Document gaps:** Note which sources were unavailable (WebFetch AND both cloudscrape.py paths failed)
 - **Prioritize safety:** If critical safety info (avalanche, hazards) unavailable, emphasize in gaps section
@@ -778,73 +769,14 @@ Every generated report must:
 
 ## Implementation Notes
 
-### Architecture (as of 2026-01-29)
+See `skills/route-researcher/docs/architecture.md` for detailed execution flow, component overview, data contracts, and design decisions.
 
-The route-researcher skill uses a hybrid architecture combining Python scripts and LLM agents:
-
-**Components:**
-
-- **Python script** (`tools/fetch_conditions.py`) - Deterministic API calls for weather, air quality, daylight, avalanche, and PeakBagger data
-- **Researcher agents** (3 total) - Web research for route info and trip reports from PeakBagger+SummitPost, WTA+Mountaineers+NWHikers+HikeOfTheWeek+OregonHikers+CascadeClimbers+MountainProject, and AllTrails
-- **Report Writer agent** - Generates markdown reports from aggregated data
-- **Report Reviewer agent** - Validates report quality before presentation
-
-**Benefits:**
-
-- **Reduced token usage** - Python handles deterministic API calls with zero LLM tokens
-- **Parallel execution** - Phase 3 runs Python script + 3 researcher agents simultaneously
-- **Inline prompts** - Agent instructions embedded in SKILL.md for reliability
-- **Clear contracts** - JSON schemas define agent inputs and outputs
-
-See `skills/route-researcher/docs/architecture.md` for detailed execution flow and data contracts.
-
-### Current Status (as of 2026-01-30)
-
-**Implemented:**
-
-- **peakbagger-cli** integration for peak search, info, and ascent data
-- Python tools directory structure
-- Report generation in user's current working directory
-- **cloudscrape.py** - Fallback fetcher with two modes:
-  - Default (fast): httpx with TLS spoofing — no browser, works for most sites
-  - `--render` (stealth browser): Patchright headless Chromium for Cloudflare-challenged and JS-rendered pages (lazy Chromium install on first use)
-  - Exits 0 on failure — callers always succeed; error detail goes to stderr
-- **Three-tier fetching strategy:** WebFetch → `cloudscrape.py` (fast) → `cloudscrape.py --render` (stealth browser)
-- **Open-Meteo Weather API** for mountain weather forecasts (temperature, precipitation, freezing level, wind)
-- **Open-Meteo Air Quality API** for AQI forecasting (US AQI scale with conditional alerts)
-- Adaptive ascent data retrieval based on peak popularity
-- **astral Python library** for daylight calculations — full twilight table (astronomical/nautical/civil dawn + dusk, sunrise, sunset); null values for white-night dates
-- **Snow line / freezing level emphasis** — per-day `snow_line_note` and `near_summit` flag in weather output
-- **Speed/time estimates** — `time_estimates` key with roped/unroped + 3-tier pacing (when `--distance-mi` and `--gain-ft` provided)
-- **Geodata fetchers** — counties (FCC), nearest hospital/ER (OSM), ranger station + USFS admin district (OSM + ArcGIS), campgrounds (OSM)
-- **High-quality trip report identification** across PeakBagger and WTA sources
-- **WTA AJAX endpoint** for trip report extraction (`{wta_url}/@@related_tripreport_listing`)
-- **Avalanche region detection** (inline in `fetch_conditions.py`) - NWAC region and URL by coordinates
-- **New source sites** (Agent 2): northwesthikers.net, hikeoftheweek.com (Cloudflare → `--render`), oregonhikers.org (WebFetch-friendly), cascadeclimbers.com, Mountain Project
-- **Weather source ranking**: NOAA + Meteoblue are most reliable; Mountain-Forecast for multi-elevation; Windy for visual wind/precip
-- **Itinerary scheduling** (`--start-time HH:MM`): `itinerary` key adds start/summit-ETA/turnaround-by/return-ETA; `after_dark: true` means projected return exceeds nautical dusk — surface as a safety warning
-- **Navigation bearings** (`--waypoint lat,lon`, repeatable): `bearings` key adds per-segment spherical azimuth (0=N, 90=E) and cumulative distance; requires 2+ waypoints
-- **Trip-report template**: `skills/route-researcher/assets/trip-report-template.md` — a climber-facing post-climb template; offer it in Phase 7 next steps
-
-**Pending Implementation:**
-
-- **Browser automation** for Mountaineers.org and AllTrails trip report extraction (requires Playwright/Chrome)
-  - Current: Both sites load content via JavaScript, cloudscrape.py cannot extract
-  - Future: Add browser automation as 3rd-tier fallback
-
-**When Python scripts are not yet implemented:**
-
-- Note in "Information Gaps" section
-- Provide manual check links
-- Continue with available data
-- Don't block report generation
-
-### peakbagger-cli Command Reference (v1.10.0+)
+### peakbagger-cli Command Reference (v1.10.0, git source)
 
 All commands use `--format json` for structured output. Run via:
 
 ```bash
-uvx --from "peakbagger-cli>=1.10.0" peakbagger <command> --format json
+uvx --from "git+https://github.com/dreamiurg/peakbagger-cli.git@v1.10.0" peakbagger <command> --format json
 ```
 
 **Available Commands:**

--- a/skills/route-researcher/SKILL.md
+++ b/skills/route-researcher/SKILL.md
@@ -53,7 +53,7 @@ Research Progress:
 2. **Search PeakBagger** using peakbagger-cli:
 
    ```bash
-   uvx --from git+https://github.com/dreamiurg/peakbagger-cli.git@v1.7.0 peakbagger peak search "{peak_name}" --format json
+   uvx --from "peakbagger-cli>=1.10.0" peakbagger peak search "{peak_name}" --format json
    ```
 
    - Parse JSON output to extract peak matches
@@ -100,7 +100,7 @@ This phase must complete before Phase 3, as coordinates are required for weather
 Retrieve detailed peak information using the peak ID from Phase 1:
 
 ```bash
-uvx --from git+https://github.com/dreamiurg/peakbagger-cli.git@v1.7.0 peakbagger peak show {peak_id} --format json
+uvx --from "peakbagger-cli>=1.10.0" peakbagger peak show {peak_id} --format json
 ```
 
 This returns structured JSON with:
@@ -173,24 +173,28 @@ Research from these sources: PeakBagger, SummitPost
 2. Extract route descriptions from peak page
 3. List recent ascents with trip reports:
    ```bash
-   uvx --from git+https://github.com/dreamiurg/peakbagger-cli.git@v1.7.0 peakbagger peak ascents {peak_id} --format json --with-tr --limit 20
+   uvx --from "peakbagger-cli>=1.10.0" peakbagger peak ascents {peak_id} --format json --with-tr --limit 20
    ```
 
 4. Identify trip reports with content (word_count > 0)
 5. Fetch content for up to 5 recent trip reports using:
 
    ```bash
-   uvx --from git+https://github.com/dreamiurg/peakbagger-cli.git@v1.7.0 peakbagger ascent show {ascent_id} --format json
+   uvx --from "peakbagger-cli>=1.10.0" peakbagger ascent show {ascent_id} --format json
    ```
 
 ## SummitPost Research
 
 1. Search: "{peak_name} site:summitpost.org"
 2. Use WebFetch to extract: route name, difficulty, approach, description, hazards
-3. If WebFetch fails, use:
+3. If WebFetch fails, use the fetching ladder:
 
    ```bash
+   # Fast path (TLS-spoofed httpx, no browser)
    uv run python {repo_root}/skills/route-researcher/tools/cloudscrape.py "{url}"
+
+   # If the above returns empty or is blocked (Cloudflare / JS-rendered):
+   uv run python {repo_root}/skills/route-researcher/tools/cloudscrape.py --render "{url}"
    ```
 
 ## Trip Report Extraction
@@ -229,9 +233,13 @@ Research from these sources: WTA, Mountaineers.org
 1. Search: "{peak_name} site:wta.org"
 2. Find the hike page and extract: trail name, difficulty, distance, elevation gain, hazards
 3. Get trip reports from AJAX endpoint: {wta_url}/@@related_tripreport_listing
-4. Fetch content for up to 5 recent trip reports using:
+4. Fetch content for up to 5 recent trip reports using the fetching ladder:
    ```bash
+   # Fast path first
    uv run python {repo_root}/skills/route-researcher/tools/cloudscrape.py "{trip_report_url}"
+
+   # If blocked or returns empty content:
+   uv run python {repo_root}/skills/route-researcher/tools/cloudscrape.py --render "{trip_report_url}"
    ```
 
 ## Mountaineers Research
@@ -241,7 +249,7 @@ Research from these sources: WTA, Mountaineers.org
 
 ## Fallback
 
-If WebFetch fails for any page, use cloudscrape.py as shown above.
+If WebFetch fails for any page, use the fetching ladder: `cloudscrape.py "{url}"` (fast) → `cloudscrape.py --render "{url}"` for JS-rendered or Cloudflare-protected pages.
 
 ## Output Format (return EXACTLY this JSON)
 
@@ -633,10 +641,10 @@ Throughout execution, follow these error handling guidelines:
 
 ### WebFetch/WebSearch Issues
 
-- **Universal fallback pattern:** Always try WebFetch first, then cloudscrape.py if it fails
-- **Automatic retry:** If WebFetch fails or returns incomplete data, immediately retry with cloudscrape.py
-- **Graceful degradation:** Missing one source shouldn't stop entire research
-- **Document gaps:** Note which sources were unavailable (both WebFetch AND cloudscrape.py failed)
+- **Fetching ladder:** WebFetch first → `cloudscrape.py "{url}"` (fast httpx, no browser) → `cloudscrape.py --render "{url}"` (Patchright stealth browser, for JS-rendered or Cloudflare-protected pages)
+- **When to use `--render`:** hikeoftheweek.com and any site where the default path returns empty or blocked content
+- **Graceful degradation:** Missing one source shouldn't stop entire research; cloudscrape.py exits 0 on failure
+- **Document gaps:** Note which sources were unavailable (WebFetch AND both cloudscrape.py paths failed)
 - **Prioritize safety:** If critical safety info (avalanche, hazards) unavailable, emphasize in gaps section
 
 ## Execution Timeouts
@@ -687,12 +695,11 @@ See `skills/route-researcher/docs/architecture.md` for detailed execution flow a
 - **peakbagger-cli** integration for peak search, info, and ascent data
 - Python tools directory structure
 - Report generation in user's current working directory
-- **cloudscrape.py** - Universal fallback for WebFetch failures, works with ANY website including:
-  - Cloudflare-protected sites (SummitPost, PeakBagger, Mountaineers.org)
-  - AllTrails (when WebFetch fails)
-  - WTA (when WebFetch fails)
-  - Any other site that blocks or limits WebFetch access
-- **Two-tier fetching strategy:** WebFetch first, cloudscrape.py as automatic fallback
+- **cloudscrape.py** - Fallback fetcher with two modes:
+  - Default (fast): httpx with TLS spoofing — no browser, works for most sites
+  - `--render` (stealth browser): Patchright headless Chromium for Cloudflare-challenged and JS-rendered pages (lazy Chromium install on first use)
+  - Exits 0 on failure — callers always succeed; error detail goes to stderr
+- **Three-tier fetching strategy:** WebFetch → `cloudscrape.py` (fast) → `cloudscrape.py --render` (stealth browser)
 - **Open-Meteo Weather API** for mountain weather forecasts (temperature, precipitation, freezing level, wind)
 - **Open-Meteo Air Quality API** for AQI forecasting (US AQI scale with conditional alerts)
 - Adaptive ascent data retrieval based on peak popularity
@@ -714,12 +721,12 @@ See `skills/route-researcher/docs/architecture.md` for detailed execution flow a
 - Continue with available data
 - Don't block report generation
 
-### peakbagger-cli Command Reference (v1.7.0)
+### peakbagger-cli Command Reference (v1.10.0+)
 
 All commands use `--format json` for structured output. Run via:
 
 ```bash
-uvx --from git+https://github.com/dreamiurg/peakbagger-cli.git@v1.7.0 peakbagger <command> --format json
+uvx --from "peakbagger-cli>=1.10.0" peakbagger <command> --format json
 ```
 
 **Available Commands:**

--- a/skills/route-researcher/SKILL.md
+++ b/skills/route-researcher/SKILL.md
@@ -203,7 +203,17 @@ Research from these sources: PeakBagger, SummitPost
 
 ## Trip Report Extraction
 
-For each report fetched, extract: date, author, route conditions, gear mentioned, hazards.
+For each report fetched, extract:
+- date, author, route conditions, gear mentioned
+- **Hazards (extract explicitly and separately):**
+  - Rockfall zones: location on route, conditions, timing guidance mentioned
+  - Icefall/serac hazard: location, stability, pre-dawn/timing advice
+  - Cornice hazard: location, buildup direction, avoidance notes
+- **Terrain detail (extract if mentioned):**
+  - Downclimb sections: location, difficulty, rappel anchors if any
+  - River/stream crossings: location, flow conditions, ford difficulty
+  - Water sources: named locations, seasonal availability
+  - Named camps or bivy sites: name/location, exposure notes
 
 ## Output Format (return EXACTLY this JSON)
 
@@ -214,7 +224,9 @@ For each report fetched, extract: date, author, route conditions, gear mentioned
     {"source": "...", "name": "...", "difficulty": "...", "description": "...", "hazards": [...]}
   ],
   "trip_reports": [
-    {"source": "...", "date": "...", "author": "...", "url": "...", "summary": "...", "conditions": "...", "has_gpx": false}
+    {"source": "...", "date": "...", "author": "...", "url": "...", "summary": "...", "conditions": "...", "has_gpx": false,
+     "rockfall": "...", "icefall": "...", "cornices": "...",
+     "downclimbs": "...", "crossings": "...", "water_sources": "...", "camps": "..."}
   ],
   "gaps": ["what couldn't be fetched and why"]
 }
@@ -255,6 +267,20 @@ Research from these sources: WTA, Mountaineers.org
 
 If WebFetch fails for any page, use the fetching ladder: `cloudscrape.py "{url}"` (fast) → `cloudscrape.py --render "{url}"` for JS-rendered or Cloudflare-protected pages.
 
+## Trip Report Extraction
+
+For each report fetched, extract:
+- date, author, route conditions, gear mentioned
+- **Hazards (extract explicitly and separately):**
+  - Rockfall zones: location on route, conditions, timing guidance mentioned
+  - Icefall/serac hazard: location, stability, pre-dawn/timing advice
+  - Cornice hazard: location, buildup direction, avoidance notes
+- **Terrain detail (extract if mentioned):**
+  - Downclimb sections: location, difficulty, rappel anchors if any
+  - River/stream crossings: location, flow conditions, ford difficulty
+  - Water sources: named locations, seasonal availability
+  - Named camps or bivy sites: name/location, exposure notes
+
 ## Output Format (return EXACTLY this JSON)
 
 ```json
@@ -264,7 +290,9 @@ If WebFetch fails for any page, use the fetching ladder: `cloudscrape.py "{url}"
     {"source": "...", "name": "...", "difficulty": "...", "description": "...", "hazards": [...]}
   ],
   "trip_reports": [
-    {"source": "...", "date": "...", "author": "...", "url": "...", "summary": "...", "conditions": "...", "has_gpx": false}
+    {"source": "...", "date": "...", "author": "...", "url": "...", "summary": "...", "conditions": "...", "has_gpx": false,
+     "rockfall": "...", "icefall": "...", "cornices": "...",
+     "downclimbs": "...", "crossings": "...", "water_sources": "...", "camps": "..."}
   ],
   "gaps": ["what couldn't be fetched and why"]
 }
@@ -291,13 +319,19 @@ Research from AllTrails
    uv run python {repo_root}/skills/route-researcher/tools/cloudscrape.py "{url}"
    ```
 
+4. From route description and any visible reviews/comments, extract if present:
+   - Rockfall zones, icefall/serac hazard, cornice hazard
+   - Downclimb sections, river/stream crossings, water sources, named camps
+
 ## Output Format (return EXACTLY this JSON)
 
 ```json
 {
   "sources": ["AllTrails"],
   "route_info": [
-    {"source": "...", "name": "...", "difficulty": "...", "distance_miles": N, "elevation_gain_ft": N, "description": "...", "hazards": [...]}
+    {"source": "...", "name": "...", "difficulty": "...", "distance_miles": N, "elevation_gain_ft": N, "description": "...", "hazards": [...],
+     "rockfall": "...", "icefall": "...", "cornices": "...",
+     "downclimbs": "...", "crossings": "...", "water_sources": "...", "camps": "..."}
   ],
   "trip_reports": [],
   "gaps": ["what couldn't be fetched and why"]
@@ -380,7 +414,17 @@ Based on route descriptions, elevation, and gear mentions, classify as:
 
 - **Route:** Use baseline structure, add landmarks/navigation from trip reports, include actual times
 - **Crux:** Describe location/difficulty, add trip report assessments, note conditions-dependent variations
-- **Hazards:** Extract ALL hazards from trip reports (rockfall, exposure, route-finding, seasonal), organize by type, include specific locations and mitigation strategies. Be comprehensive—safety-critical.
+- **Hazards:** Extract ALL hazards from trip reports. Organize by type with explicit, SEPARATE sub-sections — do NOT bury rockfall or icefall under generic "exposure":
+  - **Rockfall:** tag location, trigger (other parties / freeze-thaw / sun hitting the face), timing mitigation (pre-dawn passage, move quickly through zone)
+  - **Icefall/Serac:** tag location, stability assessment, timing mitigation (avoid afternoon, pre-dawn passage)
+  - **Cornice:** tag location, avoidance line, conditions (buildup direction, season)
+  - Other hazards (crevasses, exposure, route-finding, seasonal) as separate bullets
+  - Be comprehensive — safety-critical; include specific locations and mitigation strategies
+- **Terrain detail:** Surface the following in the report when found in trip reports/beta:
+  - Downclimbs: location, difficulty, whether rappel anchors exist
+  - River/stream crossings: location, seasonal flow, ford difficulty
+  - Water sources: named locations and per-day availability by season
+  - Named camps/bivy sites: name, location, exposure; note these come from trip reports, not the campground database
 
 **Extract Key Information:**
 

--- a/skills/route-researcher/assets/report-template.md
+++ b/skills/route-researcher/assets/report-template.md
@@ -53,7 +53,16 @@
 
 #### Road Conditions
 
-{Current access notes, seasonal closures}
+{Current access notes. Extract from researcher agents: USFS road closures, seasonal gate status, washouts, fire closures. Be explicit — note the specific road number/name and any reported obstacles.}
+
+{If no current closure info found:} Road status not confirmed. Verify before departure.
+
+**Verify current status:**
+
+- [USFS Road Conditions](https://www.fs.usda.gov/) — search ranger district for road/gate closures
+- [CalTopo Closure Layers](https://caltopo.com/) — enable "Closures" layer; pin trailhead at `https://caltopo.com/map.html#ll={latitude},{longitude}&z=14`
+- [Google Maps]({google_maps_trailhead_link}) — check current road status and satellite view
+- [Recreation.gov](https://www.recreation.gov/) — permit/reservation requirements
 
 ### Emergency Contacts
 
@@ -108,9 +117,18 @@ The route covers approximately **{round trip distance}** with **{total gain}** o
 
 **Typical completion times:**
 
-- **{fast time range}** (~{fast mph} mph, {fast gain rate}+ ft/hr): Experienced hikers, trail runners, solo climbers
-- **{moderate time range}** (~{moderate mph} mph, {moderate gain rate} ft/hr): Average fitness, steady pace with brief breaks
-- **{leisurely time range}** (~{leisurely mph} mph, {leisurely gain rate} ft/hr): Relaxed pace, groups, taking time for photos
+- **{fast_hr} hrs** (~2+ mph, 1000+ ft/hr): Experienced hikers, trail runners, solo climbers
+- **{moderate_hr} hrs** (~1.5–2 mph, 700–900 ft/hr): Average fitness, steady pace with brief breaks
+- **{leisurely_hr} hrs** (~1–1.5 mph, 500–700 ft/hr): Relaxed pace, groups, taking time for photos
+
+{If glacier/roped terrain (time_estimates.roped_hr present):}
+
+**Glacier/roped pace:**
+- **Roped (~{roped_hr} hrs):** ~1 mi/hr glacier pace (slower of distance or gain-limited)
+- **Unroped (~{unroped_hr} hrs):** ~1,000 ft/hr gain-based estimate
+
+{If time_estimates key absent from fetch_conditions.py output (--distance-mi/--gain-ft not provided):}
+*Completion time estimates not available — pass `--distance-mi` and `--gain-ft` to fetch_conditions.py for calculated times.*
 
 {Continue with detailed route description}
 
@@ -170,7 +188,22 @@ AVOID bolding: common descriptors (wet, icy, loose), general skills (scrambling,
 ### Daylight
 
 {If available from API:}
-For **{date}**, sunrise is at **{time}** and sunset at **{time}**, providing **{hours}** of daylight. Civil twilight begins at **{civil_twilight_begin}**, useful for planning alpine starts.
+For **{date}**, sunrise is at **{sunrise}** and sunset at **{sunset}**, providing **{daylight_hours}** of daylight.
+
+| Phase | Time |
+|-------|------|
+| Astronomical dawn | {astronomical_dawn or "— (white night)"} |
+| Nautical dawn | {nautical_dawn or "— (white night)"} |
+| Civil twilight (dawn) | {civil_twilight} |
+| **Sunrise** | **{sunrise}** |
+| **Sunset** | **{sunset}** |
+| Civil dusk | {civil_dusk} |
+| Nautical dusk | {nautical_dusk or "— (white night)"} |
+| Astronomical dusk | {astronomical_dusk or "— (white night)"} |
+
+{When any twilight value is null:} *At this latitude and date, the sun does not reach the threshold for nautical/astronomical twilight — effectively a white night. Plan accordingly.*
+
+**Alpine start guidance:** Civil twilight ({civil_twilight}) is the earliest practical light for travel. Nautical twilight ({nautical_dawn}) allows rough navigation by natural light. For glacier travel requiring precise footing, target no earlier than civil twilight.
 
 {If not available:}
 Daylight calculations not available. Check sunrise/sunset times for your planned date at [Sunrise-Sunset.org](https://sunrise-sunset.org/us/{location}) or [TimeAndDate.com](https://www.timeanddate.com/sun/).
@@ -213,14 +246,16 @@ AVOID bolding: descriptive terms (dry, wet, cold), common conditions (partly clo
 
 {Omit this section entirely if freezing level stays >2000 ft above peak throughout forecast period - not relevant for summer conditions}
 
-| Day | Conditions | Temperature | Precipitation |
-|-----|-----------|-------------|---------------|
-| {DayOfWeek} {Mon} {Day} {21}, {2025} (Today) | {Icon} {Conditions} | High: {temp}°F | {Precip amount/chance} |
-| {DayOfWeek} {Mon} {Day} {22}, {2025} | {Icon} {Conditions} | High: {temp}°F, Low: {temp}°F | {Precip amount/chance} |
-| {DayOfWeek} {Mon} {Day} {23}, {2025} | {Icon} {Conditions} | High: {temp}°F, Low: {temp}°F | {Precip amount/chance} |
-| {DayOfWeek} {Mon} {Day} {24}, {2025} | {Icon} {Conditions} | High: {temp}°F, Low: {temp}°F | {Precip amount/chance} |
-| {DayOfWeek} {Mon} {Day} {25}, {2025} | {Icon} {Conditions} | High: {temp}°F, Low: {temp}°F | {Precip amount/chance} |
-| {DayOfWeek} {Mon} {Day} {26}, {2025} | {Icon} {Conditions} | High: {temp}°F, Low: {temp}°F | {Precip amount/chance} |
+| Day | Conditions | Temperature | Precipitation | Snow Line |
+|-----|-----------|-------------|---------------|-----------|
+| {DayOfWeek} {Mon} {Day} {21}, {2025} (Today) | {Icon} {Conditions} | High: {temp}°F | {Precip amount/chance} | {snow_line_note} {⚠️ if near_summit} |
+| {DayOfWeek} {Mon} {Day} {22}, {2025} | {Icon} {Conditions} | High: {temp}°F, Low: {temp}°F | {Precip amount/chance} | {snow_line_note} {⚠️ if near_summit} |
+| {DayOfWeek} {Mon} {Day} {23}, {2025} | {Icon} {Conditions} | High: {temp}°F, Low: {temp}°F | {Precip amount/chance} | {snow_line_note} {⚠️ if near_summit} |
+| {DayOfWeek} {Mon} {Day} {24}, {2025} | {Icon} {Conditions} | High: {temp}°F, Low: {temp}°F | {Precip amount/chance} | {snow_line_note} {⚠️ if near_summit} |
+| {DayOfWeek} {Mon} {Day} {25}, {2025} | {Icon} {Conditions} | High: {temp}°F, Low: {temp}°F | {Precip amount/chance} | {snow_line_note} {⚠️ if near_summit} |
+| {DayOfWeek} {Mon} {Day} {26}, {2025} | {Icon} {Conditions} | High: {temp}°F, Low: {temp}°F | {Precip amount/chance} | {snow_line_note} {⚠️ if near_summit} |
+
+{snow_line_note: from `weather[].snow_line_note`; show ⚠️ when `near_summit=true` (freezing level within 2000 ft of summit); show "—" if freezing_level_ft is null}
 
 {Format notes:
 
@@ -260,10 +295,14 @@ Air quality is **good** (AQI <50) during the forecast period.
 
 **Check Current Forecasts:**
 
-- [Mountain-Forecast.com]({mountain_forecast_link}) - Summit-level forecast with multiple elevations
+*Most reliable sources (per IGC lecture recommendation): **NOAA** and **Meteoblue***
+
+- [NOAA Point Forecast]({noaa_link}) - Official NWS forecast and alerts *(most reliable)*
+- [Meteoblue]({meteoblue_link}) - High-resolution mountain weather *(most reliable)*
+- [Mountain-Forecast.com]({mountain_forecast_link}) - Multi-elevation forecast (summit / mid / base)
 - [Open-Meteo Weather]({open_meteo_weather_link}) - Detailed mountain weather data (source for this report)
 - [Open-Meteo Air Quality]({open_meteo_air_quality_link}) - Air quality forecast for this location
-- [NOAA Point Forecast]({noaa_link}) - Official NWS forecast and alerts
+- [Windy](https://www.windy.com/?{latitude},{longitude},10) - Visual wind/precip map
 
 {If winter season:}
 

--- a/skills/route-researcher/assets/report-template.md
+++ b/skills/route-researcher/assets/report-template.md
@@ -26,7 +26,7 @@
 
 {1-2 sentence synthesized description of the route character, typical approach, and what makes it notable or challenging. Example: "The route follows a classic alpine traverse combining glacier travel with moderate scrambling. Most parties complete the climb in a long day from the trailhead, navigating crevassed terrain on the approach glacier before tackling exposed rock near the summit."}
 
-**Counties traversed:** {county_name}, {state_name}{, additional counties if multiple} *(trailhead → summit; OSM/FCC data)*
+**Counties traversed:** {Iterate counties[] from fetch_conditions output; render each as "{county_name}, {state_name}" and join multiple with "; "} *(trailhead → summit; OSM/FCC data)*
 
 {If counties data unavailable:}
 **Counties traversed:** Not available — check with local forest service for jurisdiction.

--- a/skills/route-researcher/assets/report-template.md
+++ b/skills/route-researcher/assets/report-template.md
@@ -26,6 +26,11 @@
 
 {1-2 sentence synthesized description of the route character, typical approach, and what makes it notable or challenging. Example: "The route follows a classic alpine traverse combining glacier travel with moderate scrambling. Most parties complete the climb in a long day from the trailhead, navigating crevassed terrain on the approach glacier before tackling exposed rock near the summit."}
 
+**Counties traversed:** {county_name}, {state_name}{, additional counties if multiple} *(trailhead → summit; OSM/FCC data)*
+
+{If counties data unavailable:}
+**Counties traversed:** Not available — check with local forest service for jurisdiction.
+
 **Sources:** [PeakBagger]({peakbagger_url}){, [AllTrails]({alltrails_url}) if found}{, [WTA]({wta_url}) if found}{, [SummitPost]({summitpost_url}) if found}{, [Mountaineers]({mountaineers_url}) if found}{, [Mountain Project]({mountain_project_url}) if found}
 
 ## Route
@@ -49,6 +54,51 @@
 #### Road Conditions
 
 {Current access notes, seasonal closures}
+
+### Emergency Contacts
+
+{If ranger_station data available:}
+
+**Nearest Ranger Station:**
+
+- **{station name}** — {distance_miles} mi ({admin_district.district_name}, {admin_district.forest_name} if on NF land)
+  {Phone: {phone} if available}
+  {Website: {website} if available}
+
+{If admin_district present:}
+*Administrative district: {district_name}, {forest_name} ({region})*
+
+{If ranger_station unavailable or error:}
+**Nearest Ranger Station:** Data not available (OSM). Check with local forest service or park service.
+
+{If nearest_hospital data available:}
+
+**Nearest 24/7 Hospital / Emergency Room:**
+
+- **{hospital name}** — {distance_miles} mi {(emergency=yes if tagged)}
+  {Phone: {phone} if available}
+
+{List up to 3 hospitals from hospitals[]. Prefer emergency=yes entries.}
+
+*Note: Hospital data is sourced from OpenStreetMap and may be incomplete or outdated in remote areas. Verify locations before travel.*
+
+{If nearest_hospital unavailable or error:}
+**Nearest Hospital:** Data not available. Check local emergency services for the area.
+
+### Camping
+
+**Established campgrounds near trailhead** *(within ~12 mi (20 km), OSM data):*
+
+{If campgrounds available:}
+
+| Campground | Distance | Type | Operator |
+|------------|----------|------|----------|
+| {name} | {distance_miles} mi | {camp_type} | {operator or —} |
+
+{If no campgrounds found or error:}
+No established campgrounds found in OSM data near this trailhead. Check Recreation.gov or the local ranger district.
+
+**Backcountry and high camps** are not in any database — locations and conditions are extracted from trip reports and route beta in the Trip Reports and Route Description sections above.
 
 ### Route Description
 

--- a/skills/route-researcher/assets/report-template.md
+++ b/skills/route-researcher/assets/report-template.md
@@ -137,12 +137,33 @@ AVOID bolding: common descriptors (wet, icy, loose), general skills (scrambling,
 
 ### Hazards
 
-{Synthesized from multiple sources:
+{Synthesized from trip reports and route beta. Safety-critical — be comprehensive. If a hazard type was not mentioned in any source, omit the sub-bullet rather than guessing; note absence in Information Gaps only if the route type makes it expected.}
 
-- Known hazards (crevasses, rockfall, exposure)
-- Seasonal considerations
-- Bailout options
-- If trip reports mention unusual or important gear (e.g., "approach shoes recommended for talus" or "bring extra pickets"), include brief mention here}
+**Rockfall:** {Location on route (e.g., "upper couloir above 7,000 ft"), trigger sources (other parties, freeze-thaw), mitigation — move through quickly, cross before sun hits the face, consider pre-dawn passage. If no reports mention rockfall: omit.}
+
+**Icefall / Serac:** {Location, stability assessment from trip reports, timing guidance — pre-dawn passage, avoid when warm, size and frequency of seracs. If not present or not a glacier route: omit.}
+
+**Cornice:** {Location (ridge crest, summit plateau), conditions (buildup direction, season), avoidance line. If not present: omit.}
+
+**Crevasses:** {Zone(s) on glacier, bridging condition from recent reports, roped travel requirement. Omit if non-glaciated route.}
+
+**Exposure / Fall hazard:** {Location, consequence of a fall, protection options.}
+
+**Seasonal considerations:** {Early season snow, late season ice, typical window, conditions-dependent gear changes.}
+
+**Bailout options:** {Escape routes and conditions under which to use them.}
+
+{If trip reports mention unusual or important gear (e.g., "approach shoes recommended for talus" or "bring extra pickets"), include brief mention here.}
+
+### Terrain Detail
+
+**Downclimbs:** {Steep or technical reversal sections requiring downclimbing; location, difficulty, whether rappel anchors exist. Extract from trip reports. If none mentioned: omit.}
+
+**River / stream crossings:** {Location, typical flow conditions by season, ford difficulty, footwear notes. Extract from trip reports. If none: omit.}
+
+**Water sources:** {Named or described water sources along route (lake, snowmelt, stream), per-day availability by season, treat/filter note. Extract from trip reports. If none found: state "Water source locations not confirmed in available trip reports — carry sufficient water or verify before departure."}
+
+**Named camps / bivy sites:** {High camp, bivy, or established camp names/locations from trip reports and route beta. Note if windward/exposed. These are NOT from the campground database above.}
 
 ## Current Conditions
 

--- a/skills/route-researcher/assets/report-template.md
+++ b/skills/route-researcher/assets/report-template.md
@@ -196,7 +196,7 @@ AVOID bolding: common descriptors (wet, icy, loose), general skills (scrambling,
 | **Total car-to-car** | **{total_hr} hrs** |
 
 {If itinerary.after_dark is true:}
-> **⚠️ After-Dark Warning:** Projected return time ({return_eta}) is after {dusk_cutoff}. Carry a headlamp; consider an earlier start or a faster pace.
+> **⚠️ After-Dark Warning:** Projected return time ({return_eta}, 24-hr) is after {dusk_cutoff} (AM/PM). Carry a headlamp; consider an earlier start or a faster pace.
 
 {itinerary.note — display the note string from fetch_conditions.py}
 
@@ -377,7 +377,7 @@ IMPORTANT PRIORITY RULES:
 2. If PeakBagger reports are mostly <100 words, PRIORITIZE WTA/Mountaineers reports
 3. WTA trip reports are typically longer and more detailed than brief PeakBagger logs
 4. Mix sources by quality, not by platform - a detailed WTA report should appear before a brief PeakBagger report
-5. If you have WTA trip report URLs from Step 2I, you MUST include them here}
+5. If you have WTA trip report URLs from Step 3B, you MUST include them here}
 
 {If detailed PeakBagger reports exist (>100 words):}
 **PeakBagger:**
@@ -385,7 +385,7 @@ IMPORTANT PRIORITY RULES:
 - **{YYYY-MM-DD}** - [{Climber Name}]({ascent_url}) - 📝 {word_count} words{, 📍 GPX if available}
 - **{YYYY-MM-DD}** - [{Climber Name}]({ascent_url}) - 📝 {word_count} words{, 📍 GPX if available}
 
-{If WTA reports found in Step 2I - MANDATORY to include if extracted:}
+{If WTA reports found in Step 3B - MANDATORY to include if extracted:}
 **Washington Trails Association:**
 
 - **{YYYY-MM-DD}** - [{Report Title or Author}]({wta_trip_report_url})
@@ -394,7 +394,7 @@ IMPORTANT PRIORITY RULES:
 - **{YYYY-MM-DD}** - [{Report Title or Author}]({wta_trip_report_url})
 - **{YYYY-MM-DD}** - [{Report Title or Author}]({wta_trip_report_url})
 
-{If Mountaineers reports found in Step 2I:}
+{If Mountaineers reports found in Step 3B:}
 **Mountaineers.org:**
 
 - **{YYYY-MM-DD}** - [{Report Title}]({mountaineers_trip_report_url})
@@ -412,7 +412,7 @@ IMPORTANT PRIORITY RULES:
 
 ### Browse All Trip Reports
 
-{Always include PeakBagger. Include other platforms only if URLs were found during data gathering (Step 2D)}
+{Always include PeakBagger. Include other platforms only if URLs were found during data gathering (Step 3B)}
 
 - [PeakBagger Ascents](https://www.peakbagger.com/climber/PeakAscents.aspx?pid={peak_id}) - Individual climb logs with optional GPX tracks and reports
 {If WTA URL found:}

--- a/skills/route-researcher/assets/report-template.md
+++ b/skills/route-researcher/assets/report-template.md
@@ -183,6 +183,43 @@ AVOID bolding: common descriptors (wet, icy, loose), general skills (scrambling,
 
 **Named camps / bivy sites:** {High camp, bivy, or established camp names/locations from trip reports and route beta. Note if windward/exposed. These are NOT from the campground database above.}
 
+### Itinerary / Schedule
+
+{If itinerary key present in fetch_conditions.py output (--start-time + --distance-mi + --gain-ft provided):}
+
+| Milestone | Time |
+|-----------|------|
+| Trailhead depart | {start_time} |
+| Summit ETA | {summit_eta} |
+| Turnaround by | {turnaround_by} |
+| Return to trailhead | {return_eta} |
+| **Total car-to-car** | **{total_hr} hrs** |
+
+{If itinerary.after_dark is true:}
+> **⚠️ After-Dark Warning:** Projected return time ({return_eta}) is after {dusk_cutoff}. Carry a headlamp; consider an earlier start or a faster pace.
+
+{itinerary.note — display the note string from fetch_conditions.py}
+
+{If itinerary key absent from fetch_conditions.py output:}
+*Itinerary not calculated — pass `--start-time HH:MM`, `--distance-mi`, and `--gain-ft` to fetch_conditions.py.*
+
+### Navigation Bearings
+
+{If bearings key present in fetch_conditions.py output (2+ --waypoint args provided):}
+
+| Segment | Bearing | Distance | Cumulative |
+|---------|---------|----------|------------|
+| {from} → {to} | {bearing_deg}° | {distance_mi} mi | {cumulative_distance_mi} mi |
+
+{Repeat one row per segment from bearings.segments[]}
+
+**Total route distance:** {bearings.total_distance_mi} mi
+
+*Bearings are true-north spherical azimuths (0° = N, 90° = E, 180° = S, 270° = W). Apply local declination for compass use.*
+
+{If bearings key absent:}
+*Navigation bearings not calculated — pass 2 or more `--waypoint "lat,lon"` args to fetch_conditions.py.*
+
 ## Current Conditions
 
 ### Daylight
@@ -411,6 +448,13 @@ IMPORTANT PRIORITY RULES:
 
 - PeakBagger: {url}
 - {Other source names and URLs}
+
+## Post-Climb
+
+After your climb, consider filing a trip report to help future parties. A structured template is available at:
+`skills/route-researcher/assets/trip-report-template.md`
+
+It covers: conditions, cruxes, hazards encountered, water sources, camps, gear notes, timing, navigation notes, and photos.
 
 ---
 

--- a/skills/route-researcher/assets/trip-report-template.md
+++ b/skills/route-researcher/assets/trip-report-template.md
@@ -1,0 +1,104 @@
+# Trip Report: {Route Name} via {Route}
+
+**Date:** {YYYY-MM-DD}
+**Party size:** {N}
+**Summit reached:** Yes / No / Turned around at {location}
+
+---
+
+## Route Overview
+
+**Trailhead:** {name, parking area}
+**Approach:** {distance and gain to base}
+**Route:** {technical route name}
+**Total distance:** {X} mi round-trip
+**Total elevation gain:** {X} ft
+**Car-to-car time:** {X} hr
+
+---
+
+## Conditions
+
+**Snow conditions:** {consolidated / isothermal / wind slab / breakable crust / powder — note aspect and elevation}
+**Bergschrund / bergschrund status:** {open / bridged / bypassed — note location}
+**Glacier travel:** {crevasse conditions, roping-up point}
+**Rock / ridge:** {dry / icy / verglas / wet}
+**Fixed lines:** {present / absent — location}
+**Cornices:** {size, stability, aspect}
+
+---
+
+## Cruxes
+
+1. **{Crux name/location}** — {difficulty, technique used, protection placed, conditions}
+2. **{Crux name/location}** — ...
+
+---
+
+## Hazards Encountered
+
+**Rockfall / icefall:** {location, time of day, frequency}
+**Crevasse hazards:** {specific locations or zones, probe/probe results}
+**Weather:** {wind speed and direction, temperature, visibility, any unexpected changes}
+**Other:** {objective hazards not covered above}
+
+---
+
+## Water Sources
+
+| Location | Type | Available | Notes |
+|----------|------|-----------|-------|
+| {name} | Stream / snowmelt / lake | Yes / Seasonal | {treat needed, flow rate} |
+
+---
+
+## Camps / Bivy
+
+| Camp | Elevation | Site quality | Water nearby | Notes |
+|------|-----------|-------------|--------------|-------|
+| {High camp name} | {X} ft | {flat / marginal / wind-exposed} | Yes / No | {tent pads, wind walls} |
+
+---
+
+## Gear Notes
+
+**What worked:** {specific gear that proved useful}
+**What you'd change:** {gear you'd add, remove, or swap}
+**Axe use:** {self-arrest practice / required for descent / not needed}
+**Crampons:** {required from X elevation / optional / not used}
+
+---
+
+## Timing
+
+| Milestone | Time |
+|-----------|------|
+| Trailhead depart | {HH:MM} |
+| {Intermediate point} | {HH:MM} |
+| Summit / high point | {HH:MM} |
+| Turnaround | {HH:MM} |
+| Trailhead return | {HH:MM} |
+
+---
+
+## Navigation Notes
+
+**Route-finding challenges:** {any turns, cairns, wands, or GPS waypoints that were helpful}
+**GPS / GPX:** {link or note if track attached}
+**Compass bearings used:** {any bearing-critical sections — whiteout travel, glacier navigation}
+
+---
+
+## Overall Conditions Summary
+
+{1-2 sentence overall assessment for the next party: what season/conditions this trip represents, whether route is currently in shape, anything surprising.}
+
+---
+
+## Photos
+
+{Link to gallery or embed images here}
+
+---
+
+*Report filed by: {name or alias} | {YYYY-MM-DD}*

--- a/skills/route-researcher/docs/architecture.md
+++ b/skills/route-researcher/docs/architecture.md
@@ -88,14 +88,14 @@ All keys are top-level in the returned JSON object. Optional keys are emitted on
 | `daylight` | always | 8 twilight keys (null = white night) + `daylight_hours`, `timezone` |
 | `avalanche` | always | NWAC region + URL |
 | `peakbagger` | when `--peak-id` provided | ascent stats + recent ascents |
-| `counties` | always | `counties[]` with `county_name`, `county_fips`, `state_name`, `state_code` |
-| `nearest_hospital` | always | `hospitals[]` — name, distance_miles, emergency, phone; sorted emergency-first |
-| `ranger_station` | always | `stations[]` + optional `admin_district` (district_name, forest_name, region) on NF land |
+| `counties` | always | `counties[]` with `county_name`, `county_fips`, `state_name`, `state_code`; `sampled` bool (true when trailhead→summit path sampling ran), `sample_points` int |
+| `nearest_hospital` | always | `hospitals[]` — name, distance_miles, emergency, phone (optional — omitted when OSM has no phone tag); sorted emergency-first |
+| `ranger_station` | always | `stations[]` + optional `admin_district` (district_name, forest_name, region) when summit coordinates intersect a USFS ranger district |
 | `campgrounds` | always | `campgrounds[]` within ~12 mi (20 km) — name, distance_miles, camp_type, backcountry, operator |
 | `time_estimates` | `--distance-mi` + `--gain-ft` | roped_hr, unroped_hr, fast_hr, moderate_hr, leisurely_hr, note |
 | `itinerary` | `--start-time` + `--distance-mi` + `--gain-ft` | start_time, summit_eta, turnaround_by, return_eta, total_hr, after_dark bool, dusk_cutoff, note |
-| `bearings` | 2+ `--waypoint` args | segments[] (bearing_deg, distance_mi, cumulative_distance_mi) + total_distance_mi, note |
-| `gaps` | always | string array of API/fetch failures |
+| `bearings` | 2+ `--waypoint` args | segments[] (bearing_deg, distance_mi, cumulative_distance_mi) + total_distance_mi |
+| `gaps` | always | array of {"source": "...", "reason": "..."} objects |
 
 **Daylight key names (8 total):**
 
@@ -160,10 +160,10 @@ Trip report fields include hazard and terrain-detail extractions:
 For any web page, escalate through tiers until content is returned:
 
 1. **WebFetch** — fastest; works for most static sites
-2. **`cloudscrape.py "{url}"`** — httpx with TLS spoofing; no browser; works for many lightly-protected sites
+2. **`cloudscrape.py "{url}"`** — plain httpx with browser-like headers; no browser; works for many sites
 3. **`cloudscrape.py --render "{url}"`** — Patchright stealth headless Chromium; required for Cloudflare-challenged and JS-rendered pages
 
-`cloudscrape.py` always exits 0 (graceful degradation). First `--render` use installs Chromium lazily via `patchright install chromium`; subsequent calls reuse the install.
+`cloudscrape.py` always exits 0 (graceful degradation). Each `--render` invocation runs `patchright install chromium` (idempotent; fast if already installed).
 
 **Known `--render` requirements:** hikeoftheweek.com.
 
@@ -207,7 +207,7 @@ All geodata is fetched deterministically in `fetch_conditions.py` and fails soft
 | :------ | :----- | :---- |
 | `fetch_counties` | FCC Area API | Samples up to 25 points trailhead→summit; dedupes by FIPS |
 | `fetch_nearest_hospital` | OSM Overpass | Up to 3 results; `emergency=yes` preferred; haversine sort |
-| `fetch_ranger_station` | OSM Overpass + USFS ArcGIS EDW | `admin_district` added when trailhead is on NF land |
+| `fetch_ranger_station` | OSM Overpass + USFS ArcGIS EDW | `admin_district` added when summit coordinates intersect a USFS ranger district |
 | `fetch_campgrounds` | OSM Overpass | ~12 mi (20 km) radius; backcountry camps NOT included |
 
 ## Design Decisions

--- a/skills/route-researcher/docs/architecture.md
+++ b/skills/route-researcher/docs/architecture.md
@@ -4,7 +4,7 @@
 
 The route-researcher skill uses a hybrid architecture combining:
 
-- **Python scripts** for deterministic API calls (weather, air quality, daylight, peakbagger stats)
+- **Python scripts** for deterministic API calls (weather, air quality, daylight, geodata, itinerary, bearings)
 - **LLM agents** for tasks requiring judgment (web scraping, content extraction, report writing, validation)
 
 This approach minimizes token usage while maximizing parallelism and reliability.
@@ -15,7 +15,7 @@ This approach minimizes token usage while maximizing parallelism and reliability
 
 | Script | Purpose | Output |
 | :----- | :------ | :----- |
-| `fetch_conditions.py` | Unified conditions fetcher | JSON with weather, air quality, daylight, avalanche, peakbagger data |
+| `fetch_conditions.py` | Unified conditions fetcher | JSON with weather, air quality, daylight, avalanche, peakbagger, geodata, time estimates, itinerary, bearings |
 | `cloudscrape.py` | Fallback web fetcher for blocked sites | HTML content |
 
 ### Agent Types (3 total)
@@ -46,20 +46,23 @@ Phase 1-2: Peak Identification
     │ (peakbagger-cli search/info)
     ▼
 Phase 3: Data Gathering (PARALLEL)
-    ┌─────────────────────────────────────────────┐
-    │  Python: fetch_conditions.py                │
-    │  (weather, air quality, daylight,           │
-    │   avalanche, peakbagger stats)              │
-    ├─────────────────────────────────────────────┤
-    │  Agent 1: PeakBagger + SummitPost           │
-    │  Agent 2: WTA + Mountaineers                │
-    │  Agent 3: AllTrails                         │
-    │  (each fetches route info + trip reports)   │
-    └─────────────────────────────────────────────┘
+    ┌─────────────────────────────────────────────────────────────────────────┐
+    │  Python: fetch_conditions.py                                            │
+    │  (weather, air quality, daylight, avalanche, peakbagger stats,          │
+    │   counties, hospital, ranger station, campgrounds,                      │
+    │   time_estimates, itinerary, bearings)                                  │
+    ├─────────────────────────────────────────────────────────────────────────┤
+    │  Agent 1: PeakBagger + SummitPost                                       │
+    │  Agent 2: WTA + Mountaineers + NWHikers + HikeOfTheWeek +               │
+    │           OregonHikers + CascadeClimbers + MountainProject              │
+    │  Agent 3: AllTrails                                                     │
+    │  (each fetches route info + trip reports incl. hazard/terrain fields)  │
+    └─────────────────────────────────────────────────────────────────────────┘
     │
     ▼
 Phase 4: Analysis (orchestrator inline)
-    │ (route type, crux, hazards, time estimates)
+    │ (route type, crux, hazards, terrain detail, time estimates,
+    │  geodata surfacing, gap identification)
     ▼
 Phase 5: Report Writer Agent
     │ (generates markdown from data package)
@@ -67,14 +70,49 @@ Phase 5: Report Writer Agent
 Phase 6: Report Reviewer Agent
     │ (validates and fixes issues)
     ▼
-Phase 7: Present to User
+Phase 7: Present to User + offer itinerary/bearings/trip-report template
 ```
 
 ## Data Contracts
 
 All agents return JSON matching explicit schemas defined in SKILL.md.
 
+### fetch_conditions.py Output Keys
+
+All keys are top-level in the returned JSON object. Optional keys are emitted only when the corresponding CLI args are provided.
+
+| Key | Present when | Shape summary |
+| :-- | :----------- | :------------ |
+| `weather` | always | `forecast[]` with per-day `snow_line_note`, `near_summit` bool, `freezing_level_ft` |
+| `air_quality` | always | US AQI values |
+| `daylight` | always | 8 twilight keys (null = white night) + `daylight_hours`, `timezone` |
+| `avalanche` | always | NWAC region + URL |
+| `peakbagger` | when `--peak-id` provided | ascent stats + recent ascents |
+| `counties` | always | `counties[]` with `county_name`, `county_fips`, `state_name`, `state_code` |
+| `nearest_hospital` | always | `hospitals[]` — name, distance_miles, emergency, phone; sorted emergency-first |
+| `ranger_station` | always | `stations[]` + optional `admin_district` (district_name, forest_name, region) on NF land |
+| `campgrounds` | always | `campgrounds[]` within ~12 mi (20 km) — name, distance_miles, camp_type, backcountry, operator |
+| `time_estimates` | `--distance-mi` + `--gain-ft` | roped_hr, unroped_hr, fast_hr, moderate_hr, leisurely_hr, note |
+| `itinerary` | `--start-time` + `--distance-mi` + `--gain-ft` | start_time, summit_eta, turnaround_by, return_eta, total_hr, after_dark bool, dusk_cutoff, note |
+| `bearings` | 2+ `--waypoint` args | segments[] (bearing_deg, distance_mi, cumulative_distance_mi) + total_distance_mi, note |
+| `gaps` | always | string array of API/fetch failures |
+
+**Daylight key names (8 total):**
+
+```
+astronomical_dawn  nautical_dawn  civil_twilight (dawn)  sunrise
+sunset             civil_dusk     nautical_dusk           astronomical_dusk
+```
+
+Values are `null` when the sun does not reach the threshold (high-latitude white nights).
+
+**Itinerary safety signal:** `after_dark: true` means the projected return exceeds the nautical dusk cutoff. The report writer must surface this prominently.
+
+**Bearings bearing_deg convention:** spherical azimuth, 0–360 (0 = N, 90 = E, 180 = S, 270 = W). Apply local declination before compass use.
+
 ### Researcher Agent Output
+
+Trip report fields include hazard and terrain-detail extractions:
 
 ```json
 {
@@ -83,7 +121,12 @@ All agents return JSON matching explicit schemas defined in SKILL.md.
     {"source": "...", "name": "...", "difficulty": "...", "description": "...", "hazards": [...]}
   ],
   "trip_reports": [
-    {"source": "...", "date": "...", "author": "...", "url": "...", "summary": "...", "conditions": "..."}
+    {
+      "source": "...", "date": "...", "author": "...", "url": "...",
+      "summary": "...", "conditions": "...", "has_gpx": false,
+      "rockfall": "...", "icefall": "...", "cornices": "...",
+      "downclimbs": "...", "crossings": "...", "water_sources": "...", "camps": "..."
+    }
   ],
   "gaps": ["what couldn't be fetched and why"]
 }
@@ -112,6 +155,18 @@ All agents return JSON matching explicit schemas defined in SKILL.md.
 }
 ```
 
+## Fetching Strategy (Three-Tier Ladder)
+
+For any web page, escalate through tiers until content is returned:
+
+1. **WebFetch** — fastest; works for most static sites
+2. **`cloudscrape.py "{url}"`** — httpx with TLS spoofing; no browser; works for many lightly-protected sites
+3. **`cloudscrape.py --render "{url}"`** — Patchright stealth headless Chromium; required for Cloudflare-challenged and JS-rendered pages
+
+`cloudscrape.py` always exits 0 (graceful degradation). First `--render` use installs Chromium lazily via `patchright install chromium`; subsequent calls reuse the install.
+
+**Known `--render` requirements:** hikeoftheweek.com.
+
 ## Error Handling
 
 | Layer | Failure | Response |
@@ -124,6 +179,37 @@ All agents return JSON matching explicit schemas defined in SKILL.md.
 
 **Minimum viable report:** Peak metadata + at least one route source + conditions data.
 
+## Source Coverage
+
+### Agent 1: PeakBagger + SummitPost
+
+peakbagger-cli (v1.10.0+) for structured peak/ascent data. SummitPost via WebFetch / cloudscrape.py ladder.
+
+### Agent 2: WTA + Mountaineers + Regional Sources
+
+- **WTA** — AJAX trip report endpoint (`{wta_url}/@@related_tripreport_listing`)
+- **Mountaineers.org** — route beta, technical requirements
+- **NWHikers** (northwesthikers.net / nwhikers.net) — first-person trip reports
+- **HikeOfTheWeek** (hikeoftheweek.com) — MUST use `--render` (Cloudflare-protected)
+- **Oregon Hikers Field Guide** (oregonhikers.org) — static MediaWiki, WebFetch-friendly
+- **Cascade Climbers** (cascadeclimbers.com) — technical beta, forum reports
+- **Mountain Project** — rock/ridge sections, grades, gear
+
+### Agent 3: AllTrails
+
+WebFetch / cloudscrape.py ladder. Route stats, reviews, seasonal info.
+
+## Geodata Fetchers
+
+All geodata is fetched deterministically in `fetch_conditions.py` and fails soft (error → `gaps[]`):
+
+| Fetcher | Source | Notes |
+| :------ | :----- | :---- |
+| `fetch_counties` | FCC Area API | Samples up to 25 points trailhead→summit; dedupes by FIPS |
+| `fetch_nearest_hospital` | OSM Overpass | Up to 3 results; `emergency=yes` preferred; haversine sort |
+| `fetch_ranger_station` | OSM Overpass + USFS ArcGIS EDW | `admin_district` added when trailhead is on NF land |
+| `fetch_campgrounds` | OSM Overpass | ~12 mi (20 km) radius; backcountry camps NOT included |
+
 ## Design Decisions
 
 ### Why Python for API calls?
@@ -131,7 +217,7 @@ All agents return JSON matching explicit schemas defined in SKILL.md.
 - Deterministic: No LLM judgment needed for structured API responses
 - Reliable: No prompt variability
 - Fast: Direct HTTP calls, no agent overhead
-- Cheap: Zero tokens for weather/daylight/air quality
+- Cheap: Zero tokens for weather/daylight/air quality/geodata/itinerary/bearings
 
 ### Why inline agent prompts?
 
@@ -143,8 +229,12 @@ All agents return JSON matching explicit schemas defined in SKILL.md.
 ### Why 3 researcher agents (not 5)?
 
 - Balance: Enough parallelism without coordination overhead
-- Source grouping: Related sources assigned together (PeakBagger+SummitPost, WTA+Mountaineers)
+- Source grouping: Related sources assigned together
 - Trip report batching: Each agent fetches its own reports (no separate fetch step)
+
+### Why Patchright over Playwright?
+
+Patchright is a drop-in Playwright fork with stealth patches (TLS fingerprint, bot-detection bypass). Required for Cloudflare-challenged sites. Lazy Chromium install keeps the base environment light; only installed on first `--render` use.
 
 ## Maintenance
 
@@ -160,3 +250,11 @@ To add new data sources:
 2. Update the relevant component
 3. Update data aggregation in Phase 3C
 4. Update Report Writer prompt if new sections needed
+
+To add new fetch_conditions.py output keys:
+
+1. Implement in `fetch_conditions.py` + tests
+2. Document the key in SKILL.md Step 3A bullet list
+3. Add to Phase 5A data package JSON shape
+4. Add template section in `assets/report-template.md`
+5. Update this architecture doc

--- a/skills/route-researcher/tools/README.md
+++ b/skills/route-researcher/tools/README.md
@@ -94,19 +94,32 @@ uv run python fetch_conditions.py \
 - `--elevation` (required): Elevation in meters
 - `--peak-name` (required): Peak name
 - `--peak-id` (optional): PeakBagger peak ID for stats/ascents
+- `--trailhead` (optional): Trailhead coordinates as "lat,lon" — enables multi-county sampling and trailhead-relative hospital/ranger lookups
 - `--date` (optional): Date as YYYY-MM-DD (default: today)
+- `--distance-mi` (optional): Round-trip distance in miles — required for `time_estimates` and `itinerary`
+- `--gain-ft` (optional): Total elevation gain in feet — required for `time_estimates` and `itinerary`
+- `--start-time` (optional): Trip start time as HH:MM — requires `--distance-mi` and `--gain-ft`; adds `itinerary` key
+- `--waypoint` (optional, repeatable): Waypoint as "lat,lon" — provide 2+ to add `bearings` key
 
 **Output:**
 
-Returns unified JSON with keys: `weather`, `air_quality`, `daylight`, `avalanche`, `peakbagger`, `gaps`.
+Returns unified JSON. Always-present keys: `weather`, `air_quality`, `daylight`, `avalanche`, `peakbagger` (when `--peak-id` given), `counties`, `nearest_hospital`, `ranger_station`, `campgrounds`, `gaps`.
+
+Conditional keys (only emitted when inputs are provided):
+- `time_estimates` — roped/unroped + 3-tier pacing (requires `--distance-mi` + `--gain-ft`)
+- `itinerary` — start/summit-ETA/turnaround-by/return-ETA, `after_dark` bool, `dusk_cutoff` (requires `--start-time` + `--distance-mi` + `--gain-ft`)
+- `bearings` — per-segment spherical azimuth and distance (requires 2+ `--waypoint` args)
 
 **Data Sources:**
 
-- Open-Meteo Weather API (7-day forecast, freezing levels)
+- Open-Meteo Weather API (7-day forecast, freezing levels, per-day `snow_line_note`/`near_summit`)
 - Open-Meteo Air Quality API (US AQI)
-- astral library (sunrise, sunset, civil twilight)
+- astral library (full 8-key twilight table; null on white-night dates)
 - NWAC region detection by coordinates
 - peakbagger-cli (ascent statistics and recent ascents)
+- FCC Area API (counties trailhead→summit)
+- OSM Overpass (nearest hospital/ER, ranger station, campgrounds within ~12 mi)
+- USFS ArcGIS EDW (admin district when on NF land)
 
 **Testing:**
 

--- a/skills/route-researcher/tools/README.md
+++ b/skills/route-researcher/tools/README.md
@@ -22,7 +22,7 @@ Fetches HTML content from websites, with optional JS-rendering for Cloudflare-pr
 **Usage:**
 
 ```bash
-# Default: fast httpx fetch (TLS-spoofed, no browser)
+# Default: fast httpx fetch (browser-like headers, no browser)
 uv run python cloudscrape.py "https://www.peakbagger.com/peak.aspx?pid=1798"
 
 # --render: Patchright headless browser for JS-rendered / Cloudflare-challenged pages
@@ -36,25 +36,24 @@ uv run python cloudscrape.py --render "https://www.hikeoftheweek.com/some-hike"
 - `--timeout` (optional): Request timeout in seconds (default: 30)
 
 **Output:**
-Returns the full HTML content to stdout. On failure, exits 0 with a JSON error note to stderr so callers always succeed.
+Returns the full HTML content to stdout. On failure, exits 0 with a JSON error note to stdout so callers always succeed.
 
 **Purpose:**
 
-- Default path: fast TLS-spoofed HTTP via httpx (no browser required)
+- Default path: plain httpx with browser-like headers (no browser required, no TLS spoofing)
 - `--render` path: stealth headless Chromium via Patchright for pages that block plain HTTP or require JavaScript execution
 
 **Behavior:**
 
-- Default: httpx with spoofed TLS fingerprint; fast, no external install
+- Default: plain httpx with browser-like headers; fast, no external install, no TLS spoofing
 - `--render`: launches Patchright (undetected Playwright); Chromium is installed lazily on first use via `patchright install chromium` — base install stays light
-- Any failure exits 0 (graceful degradation); error details go to stderr as JSON
+- Any failure exits 0 (graceful degradation); error details go to stdout as JSON
 
 **Dependencies:**
 
 - httpx (default fetch path)
 - patchright (stealth headless browser, `--render` path)
 - click (CLI)
-- rich (console output)
 
 **Use Cases:**
 
@@ -94,7 +93,7 @@ uv run python fetch_conditions.py \
 - `--elevation` (required): Elevation in meters
 - `--peak-name` (required): Peak name
 - `--peak-id` (optional): PeakBagger peak ID for stats/ascents
-- `--trailhead` (optional): Trailhead coordinates as "lat,lon" — enables multi-county sampling and trailhead-relative hospital/ranger lookups
+- `--trailhead` (optional): Trailhead coordinates as "lat,lon" — enables multi-county path sampling (trailhead→summit); hospital/ranger lookups always run from the summit regardless
 - `--date` (optional): Date as YYYY-MM-DD (default: today)
 - `--distance-mi` (optional): Round-trip distance in miles — required for `time_estimates` and `itinerary`
 - `--gain-ft` (optional): Total elevation gain in feet — required for `time_estimates` and `itinerary`
@@ -274,8 +273,8 @@ The skill:
 
 **Typical execution times:**
 
-- `fetch_conditions.py`: 2-5s without --peak-id; 30-120s with --peak-id (peakbagger-cli is slow)
-- `cloudscrape.py`: 1-3s (HTTP with Cloudflare bypass)
+- `fetch_conditions.py`: 5-15s without --peak-id (includes OSM/FCC geodata calls); 30-120s with --peak-id (peakbagger-cli is slow)
+- `cloudscrape.py`: 1-3s default httpx; 10-30s first `--render` (Chromium install), 3-8s subsequent `--render`
 
 **Timeouts:**
 
@@ -335,7 +334,6 @@ Managed in `pyproject.toml`:
 
 - **click** - CLI framework
 - **httpx** - Modern HTTP client
-- **rich** - Rich terminal output
 - **astral** - Astronomy calculations (daylight)
 - **patchright** - Stealth headless browser (`--render` path in cloudscrape.py)
 

--- a/skills/route-researcher/tools/README.md
+++ b/skills/route-researcher/tools/README.md
@@ -17,52 +17,59 @@ These tools are invoked by the `route-researcher` skill to fetch real-time data 
 
 ### cloudscrape.py
 
-Fetches HTML content from Cloudflare-protected websites using cloudscraper.
+Fetches HTML content from websites, with optional JS-rendering for Cloudflare-protected or JavaScript-heavy pages.
 
 **Usage:**
 
 ```bash
+# Default: fast httpx fetch (TLS-spoofed, no browser)
 uv run python cloudscrape.py "https://www.peakbagger.com/peak.aspx?pid=1798"
+
+# --render: Patchright headless browser for JS-rendered / Cloudflare-challenged pages
+uv run python cloudscrape.py --render "https://www.hikeoftheweek.com/some-hike"
 ```
 
 **Parameters:**
 
 - `url` (required): URL to fetch
+- `--render` (optional): Use Patchright stealth browser for JS-rendered or Cloudflare-protected pages
 - `--timeout` (optional): Request timeout in seconds (default: 30)
 
 **Output:**
-Returns the full HTML content to stdout.
+Returns the full HTML content to stdout. On failure, exits 0 with a JSON error note to stderr so callers always succeed.
 
 **Purpose:**
 
-- Bypasses Cloudflare bot protection on PeakBagger and SummitPost
-- Uses cloudscraper library which solves Cloudflare's JavaScript challenges
-- No browser required - pure HTTP with smart request mimicking
+- Default path: fast TLS-spoofed HTTP via httpx (no browser required)
+- `--render` path: stealth headless Chromium via Patchright for pages that block plain HTTP or require JavaScript execution
 
 **Behavior:**
 
-- Creates scraper instance with Chrome browser profile
-- Mimics macOS desktop Chrome browser
-- Automatically solves Cloudflare challenges
-- Returns raw HTML for parsing by the skill
+- Default: httpx with spoofed TLS fingerprint; fast, no external install
+- `--render`: launches Patchright (undetected Playwright); Chromium is installed lazily on first use via `patchright install chromium` — base install stays light
+- Any failure exits 0 (graceful degradation); error details go to stderr as JSON
 
 **Dependencies:**
 
-- cloudscraper (Cloudflare bypass)
+- httpx (default fetch path)
+- patchright (stealth headless browser, `--render` path)
 - click (CLI)
 - rich (console output)
 
 **Use Cases:**
 
-- Fetching PeakBagger peak pages
-- Fetching SummitPost route descriptions
-- Any Cloudflare-protected climbing/hiking resource
+- Fetching PeakBagger, SummitPost, WTA pages (default path usually sufficient)
+- hikeoftheweek.com and other Cloudflare-challenged sites (require `--render`)
+- Any site that serves content via JavaScript (require `--render`)
 
 **Example:**
 
 ```bash
-# Fetch Mount Pilchuck page from PeakBagger
+# Standard fetch — fast, no browser
 uv run python cloudscrape.py "https://www.peakbagger.com/peak.aspx?pid=1798" | grep -i "elevation"
+
+# JS-rendered / Cloudflare page
+uv run python cloudscrape.py --render "https://www.hikeoftheweek.com/mount-baker"
 ```
 
 ---
@@ -135,11 +142,12 @@ Python 3.11+ (specified in `.python-version`)
 
 **Cloudflare Blocking Requests**
 
-The `cloudscrape.py` tool handles Cloudflare protection, but may occasionally fail:
+The `cloudscrape.py` tool handles Cloudflare and JS-rendered pages. If the default path fails:
 
-- Skill automatically falls back to available sources
-- Check "Information Gaps" section in generated reports
-- Use manual verification links provided
+- Retry with `--render` flag to use Patchright stealth browser
+- First `--render` use installs Chromium lazily (`patchright install chromium`) — subsequent calls are fast
+- If both paths fail, the skill notes it in "Information Gaps" and continues
+- Use manual verification links provided in the report
 
 **No Route Beta Generated**
 
@@ -316,6 +324,6 @@ Managed in `pyproject.toml`:
 - **httpx** - Modern HTTP client
 - **rich** - Rich terminal output
 - **astral** - Astronomy calculations (daylight)
-- **cloudscraper** - Cloudflare bypass
+- **patchright** - Stealth headless browser (`--render` path in cloudscrape.py)
 
 Dev dependencies: pytest

--- a/skills/route-researcher/tools/cloudscrape.py
+++ b/skills/route-researcher/tools/cloudscrape.py
@@ -1,36 +1,101 @@
 #!/usr/bin/env python3
-"""Fetch content from Cloudflare-protected websites using cloudscraper"""
+"""Fetch content from protected websites.
 
-import sys
+Default path: httpx with browser-like headers (handles most sites).
+--render path: Patchright (stealth headless Chromium) for JS-rendered /
+Cloudflare-challenged pages. Patchright installs its own Chromium lazily on
+first --render use via `patchright install chromium`.
+
+CLI contract (preserved):
+  positional URL, --timeout seconds, HTML to stdout, exit 0 on failure.
+
+# TODO: escalation ladder — nodriver (system Chrome, no download) or hosted
+# Cloudflare-bypass API — add here if Patchright gets blocked.
+"""
+
+import json
 
 import click
-import cloudscraper
+import httpx
 from rich.console import Console
 
 console = Console(stderr=True)
+
+_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/124.0.0.0 Safari/537.36"
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.9",
+}
+
+
+def _fetch_with_render(url: str, timeout: int) -> str:
+    """Fetch a JS-rendered page using Patchright (stealth Chromium).
+
+    Installs Chromium on first call if not already installed.
+    Raises on any failure — caller must handle gracefully.
+    """
+    try:
+        from patchright.sync_api import sync_playwright
+    except ImportError as e:
+        raise ImportError("patchright is not installed. Run: uv sync") from e
+
+    import subprocess
+
+    # Lazy Chromium install — only downloads once; subsequent calls are instant.
+    subprocess.run(
+        ["patchright", "install", "chromium"],
+        check=False,
+        capture_output=True,
+    )
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        try:
+            page = browser.new_page()
+            page.goto(url, timeout=timeout * 1000, wait_until="domcontentloaded")
+            return page.content()
+        finally:
+            browser.close()
 
 
 @click.command()
 @click.argument("url")
 @click.option("--timeout", default=30, help="Request timeout in seconds")
-def cli(url: str, timeout: int):
-    """Fetch HTML content from Cloudflare-protected URL"""
+@click.option("--render", is_flag=True, default=False, help="Use Patchright headless browser")
+def cli(url: str, timeout: int, render: bool):
+    """Fetch HTML content from a URL, optionally via headless browser."""
+    if render:
+        try:
+            html = _fetch_with_render(url, timeout)
+            click.echo(html, nl=False)
+        except Exception as e:
+            error_note = {
+                "error": str(e),
+                "note": f"Render fetch failed for {url}. Check the URL manually.",
+                "url": url,
+            }
+            click.echo(json.dumps(error_note))
+        return
+
+    # Default: httpx with browser-like headers
     try:
-        # Create scraper instance
-        scraper = cloudscraper.create_scraper(
-            browser={"browser": "chrome", "platform": "darwin", "desktop": True}
-        )
-
-        # Fetch the page
-        response = scraper.get(url, timeout=timeout)
-        response.raise_for_status()
-
-        # Output HTML to stdout
-        click.echo(response.text, nl=False)
-
+        with httpx.Client(
+            timeout=float(timeout), headers=_HEADERS, follow_redirects=True
+        ) as client:
+            response = client.get(url)
+            response.raise_for_status()
+            click.echo(response.text, nl=False)
     except Exception as e:
-        console.print(f"[red]Error fetching URL: {e}[/red]")
-        sys.exit(1)
+        error_note = {
+            "error": str(e),
+            "note": f"HTTP fetch failed for {url}. Try --render for Cloudflare-protected pages.",
+            "url": url,
+        }
+        click.echo(json.dumps(error_note))
 
 
 if __name__ == "__main__":

--- a/skills/route-researcher/tools/cloudscrape.py
+++ b/skills/route-researcher/tools/cloudscrape.py
@@ -17,9 +17,8 @@ import json
 
 import click
 import httpx
-from rich.console import Console
 
-console = Console(stderr=True)
+_CHROMIUM_INSTALLED = False
 
 _HEADERS = {
     "User-Agent": (
@@ -43,14 +42,17 @@ def _fetch_with_render(url: str, timeout: int) -> str:
     except ImportError as e:
         raise ImportError("patchright is not installed. Run: uv sync") from e
 
-    import subprocess
+    global _CHROMIUM_INSTALLED
+    if not _CHROMIUM_INSTALLED:
+        import subprocess
 
-    # Lazy Chromium install — only downloads once; subsequent calls are instant.
-    subprocess.run(
-        ["patchright", "install", "chromium"],
-        check=False,
-        capture_output=True,
-    )
+        proc = subprocess.run(
+            ["patchright", "install", "chromium"],
+            check=False,
+            capture_output=True,
+        )
+        if proc.returncode == 0:
+            _CHROMIUM_INSTALLED = True
 
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=True)

--- a/skills/route-researcher/tools/fetch_conditions.py
+++ b/skills/route-researcher/tools/fetch_conditions.py
@@ -576,6 +576,129 @@ def estimate_times(distance_mi: float, gain_ft: float) -> dict[str, Any]:
     }
 
 
+def build_itinerary(
+    start_time: str,
+    distance_mi: float,
+    gain_ft: float,
+    daylight: dict[str, Any],
+) -> dict[str, Any]:
+    """Generate a climb timeline from start time, route stats, and daylight.
+
+    Turnaround definition: latest time to begin descent and return before nautical dusk
+    (dusk - descent_hr).  If that time is before the summit ETA the route cannot be
+    completed before dark, and after_dark=True.
+
+    All arithmetic uses timedelta from start_dt so pre-dawn starts and after-midnight
+    finishes are handled correctly without re-parsing wall-clock strings.
+    Dusk is anchored to the start date (or day+1 when the dusk time-of-day is earlier
+    than start time-of-day, e.g. a 23:00 start with 22:00 dusk).
+    """
+    from datetime import datetime, timedelta
+
+    fmt_in = "%H:%M"
+    fmt_out = "%H:%M"
+
+    try:
+        start_dt = datetime.strptime(start_time, fmt_in)
+    except ValueError:
+        return {"error": f"Invalid start_time format: {start_time!r}. Use HH:MM."}
+
+    times = estimate_times(distance_mi, gain_ft)
+
+    # Ascent: moderate pace; descent: fast pace (downhill)
+    ascent_hr = times["moderate_hr"]
+    descent_hr = times["fast_hr"] * 0.5
+    total_hr = round(ascent_hr + descent_hr, 1)
+
+    summit_dt = start_dt + timedelta(hours=ascent_hr)
+    return_dt = summit_dt + timedelta(hours=descent_hr)
+
+    # Dusk cutoff: prefer nautical_dusk → civil_dusk → sunset → None
+    dusk_str = daylight.get("nautical_dusk") or daylight.get("civil_dusk") or daylight.get("sunset")
+    dusk_dt = None
+    if dusk_str:
+        for fmt in ("%I:%M %p", "%H:%M"):
+            try:
+                dusk_dt = datetime.strptime(dusk_str, fmt)
+                break
+            except ValueError:
+                continue
+
+    if dusk_dt:
+        # Anchor dusk to the same calendar date as start.  When the dusk time-of-day
+        # is earlier than start (e.g. 23:00 start, 22:00 dusk) it must be day+1.
+        if dusk_dt.time() < start_dt.time():
+            dusk_dt += timedelta(days=1)
+
+        # Turnaround = latest moment to begin descent and reach the trailhead before dusk.
+        turnaround_dt = dusk_dt - timedelta(hours=descent_hr)
+        # Clamp: turnaround cannot be before start (edge case: tiny window)
+        if turnaround_dt < start_dt:
+            turnaround_dt = start_dt
+        after_dark = return_dt > dusk_dt
+    else:
+        turnaround_dt = summit_dt  # no dusk info — use summit as turnaround
+        after_dark = False
+
+    return {
+        "start_time": start_time,
+        "summit_eta": summit_dt.strftime(fmt_out),
+        "turnaround_by": turnaround_dt.strftime(fmt_out),
+        "return_eta": return_dt.strftime(fmt_out),
+        "after_dark": after_dark,
+        "dusk_cutoff": dusk_str,
+        "total_hr": total_hr,
+        "note": (
+            "Ascent at moderate pace; descent at fast pace. "
+            "Adjust for terrain, conditions, and party speed."
+        ),
+    }
+
+
+def compute_bearings(waypoints: list[tuple[float, float]]) -> dict[str, Any]:
+    """Return per-segment compass bearings and distances for an ordered list of waypoints.
+
+    Each segment: bearing_deg (0–360), distance_mi, cumulative_distance_mi, from/to indices.
+    """
+    import math as _math
+
+    if len(waypoints) < 2:
+        return {"segments": [], "total_distance_mi": 0.0}
+
+    segments = []
+    cumulative = 0.0
+
+    for i in range(len(waypoints) - 1):
+        lat1, lon1 = float(waypoints[i][0]), float(waypoints[i][1])
+        lat2, lon2 = float(waypoints[i + 1][0]), float(waypoints[i + 1][1])
+
+        # Forward azimuth (bearing) using spherical formula
+        phi1 = _math.radians(lat1)
+        phi2 = _math.radians(lat2)
+        dl = _math.radians(lon2 - lon1)
+        x = _math.sin(dl) * _math.cos(phi2)
+        y = _math.cos(phi1) * _math.sin(phi2) - _math.sin(phi1) * _math.cos(phi2) * _math.cos(dl)
+        bearing = (_math.degrees(_math.atan2(x, y)) + 360) % 360
+
+        dist = _haversine_miles(lat1, lon1, lat2, lon2)
+        cumulative += dist
+
+        segments.append(
+            {
+                "from": i,
+                "to": i + 1,
+                "bearing_deg": round(bearing, 1),
+                "distance_mi": round(dist, 2),
+                "cumulative_distance_mi": round(cumulative, 2),
+            }
+        )
+
+    return {
+        "segments": segments,
+        "total_distance_mi": round(cumulative, 2),
+    }
+
+
 def run_peakbagger_stats(peak_id: int) -> dict[str, Any]:
     """Run peakbagger-cli to get ascent statistics."""
     try:
@@ -638,10 +761,17 @@ def run_peakbagger_ascents(peak_id: int, within: str = "1y") -> dict[str, Any]:
     "--distance-mi",
     type=float,
     default=None,
-    help="Round-trip distance in miles (for time estimates)",
+    help="Round-trip distance in miles (for time estimates and itinerary)",
 )
 @click.option(
     "--gain-ft", type=float, default=None, help="Total elevation gain in feet (for time estimates)"
+)
+@click.option("--start-time", default=None, help="Planned start time as HH:MM (for itinerary)")
+@click.option(
+    "--waypoint",
+    "waypoints",
+    multiple=True,
+    help="Waypoint as lat,lon (repeat for multiple; enables navigation bearings)",
 )
 def cli(
     coordinates: str,
@@ -652,6 +782,8 @@ def cli(
     trailhead: str,
     distance_mi: float,
     gain_ft: float,
+    start_time: str,
+    waypoints: tuple,
 ):
     """Fetch all conditions data for a peak.
 
@@ -743,6 +875,18 @@ def cli(
 
     if distance_mi is not None and gain_ft is not None:
         output["time_estimates"] = estimate_times(distance_mi, gain_ft)
+
+    # Itinerary: needs start_time + distance + gain + daylight
+    if start_time and distance_mi is not None and gain_ft is not None:
+        output["itinerary"] = build_itinerary(start_time, distance_mi, gain_ft, daylight)
+
+    # Navigation bearings: needs 2+ waypoints
+    if waypoints and len(waypoints) >= 2:
+        try:
+            parsed = [tuple(map(float, w.split(","))) for w in waypoints]
+            output["bearings"] = compute_bearings(parsed)
+        except Exception as e:
+            gaps.append({"source": "Navigation bearings", "reason": str(e)})
 
     click.echo(json.dumps(output, indent=2))
 

--- a/skills/route-researcher/tools/fetch_conditions.py
+++ b/skills/route-researcher/tools/fetch_conditions.py
@@ -44,7 +44,7 @@ WEATHER_CODES = {
 PEAKBAGGER_CMD = [
     "uvx",
     "--from",
-    "git+https://github.com/dreamiurg/peakbagger-cli.git@v1.7.0",
+    "peakbagger-cli>=1.10.0",
     "peakbagger",
 ]
 
@@ -246,6 +246,264 @@ def fetch_avalanche(lat: float, lon: float) -> dict[str, Any]:
     }
 
 
+def _haversine_miles(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Haversine distance in miles between two lat/lon points."""
+    import math
+
+    R = 3958.8  # Earth radius in miles
+    phi1, phi2 = math.radians(lat1), math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dlam = math.radians(lon2 - lon1)
+    a = math.sin(dphi / 2) ** 2 + math.cos(phi1) * math.cos(phi2) * math.sin(dlam / 2) ** 2
+    return R * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+
+
+def _sample_line(
+    start: tuple[float, float], end: tuple[float, float], n: int
+) -> list[tuple[float, float]]:
+    """Return n evenly-spaced points along the line from start to end (inclusive)."""
+    if n <= 1:
+        return [start]
+    points = []
+    for i in range(n):
+        t = i / (n - 1)
+        lat = start[0] + t * (end[0] - start[0])
+        lon = start[1] + t * (end[1] - start[1])
+        points.append((lat, lon))
+    return points
+
+
+FCC_AREA_URL = "https://geo.fcc.gov/api/census/area"
+OVERPASS_URL = "https://overpass-api.de/api/interpreter"
+USFS_DISTRICTS_URL = (
+    "https://apps.fs.usda.gov/arcx/rest/services/EDW/EDW_RangerDistricts_01/MapServer/0/query"
+)
+
+
+def fetch_counties(
+    summit: tuple[float, float],
+    trailhead: tuple[float, float] | None,
+    n_samples: int = 25,
+) -> dict[str, Any]:
+    """Return counties traversed from trailhead to summit via FCC Area API.
+
+    If trailhead is None, only the summit point is queried and a note is added.
+    Deduplicates by county_fips.
+    """
+    try:
+        points = _sample_line(trailhead, summit, n_samples) if trailhead else [summit]
+        seen: dict[str, dict] = {}
+        with httpx.Client(timeout=30.0) as client:
+            for lat, lon in points:
+                try:
+                    resp = client.get(
+                        FCC_AREA_URL,
+                        params={"lat": float(lat), "lon": float(lon), "format": "json"},
+                    )
+                    resp.raise_for_status()
+                    data = resp.json()
+                    for r in data.get("results", []):
+                        fips = r.get("county_fips")
+                        if fips and fips not in seen:
+                            seen[fips] = {
+                                "county_name": r.get("county_name"),
+                                "county_fips": fips,
+                                "state_name": r.get("state_name"),
+                                "state_code": r.get("state_code"),
+                            }
+                except Exception:
+                    continue  # single-point failure is non-fatal
+
+        if not seen and points:
+            return {
+                "error": "FCC Area API returned no data for any sampled point.",
+                "note": "County lookup failed; check https://geo.fcc.gov/api/census/area",
+                "counties": [],
+            }
+
+        result: dict[str, Any] = {"counties": list(seen.values())}
+        if trailhead:
+            result["sampled"] = True
+            result["sample_points"] = len(points)
+        else:
+            result["note"] = (
+                "Only summit county returned — provide --trailhead to sample the full route."
+            )
+        return result
+    except Exception as e:
+        return {
+            "error": str(e),
+            "note": "County lookup failed; check FCC Area API.",
+            "counties": [],
+        }
+
+
+def fetch_nearest_hospital(lat: float, lon: float) -> dict[str, Any]:
+    """Return nearest hospitals via OSM Overpass, sorted by distance.
+
+    Prefers emergency=yes / opening_hours=24/7 but does not require them.
+    Returns top 3 results.
+    """
+    query = f"""
+[out:json][timeout:25];
+nwr[amenity=hospital](around:50000,{float(lat)},{float(lon)});
+out center tags;
+"""
+    try:
+        with httpx.Client(timeout=35.0) as client:
+            resp = client.post(OVERPASS_URL, data={"data": query})
+            resp.raise_for_status()
+            elements = resp.json().get("elements", [])
+
+        hospitals = []
+        for el in elements:
+            tags = el.get("tags", {})
+            elat = el.get("lat") or (el.get("center") or {}).get("lat")
+            elon = el.get("lon") or (el.get("center") or {}).get("lon")
+            if elat is None or elon is None:
+                continue
+            entry: dict[str, Any] = {
+                "name": tags.get("name", "Unknown hospital"),
+                "lat": elat,
+                "lon": elon,
+                "distance_miles": round(_haversine_miles(lat, lon, elat, elon), 1),
+                "emergency": tags.get("emergency"),
+                "opening_hours": tags.get("opening_hours"),
+            }
+            if "phone" in tags:
+                entry["phone"] = tags["phone"]
+            hospitals.append(entry)
+
+        # Sort: emergency=yes first, then by distance
+        hospitals.sort(key=lambda h: (h.get("emergency") != "yes", h["distance_miles"]))
+        return {"hospitals": hospitals[:3]}
+    except Exception as e:
+        return {"error": str(e), "note": "Hospital lookup failed; check OSM Overpass."}
+
+
+def fetch_ranger_station(lat: float, lon: float) -> dict[str, Any]:
+    """Return nearest ranger stations (OSM) plus USFS administrative district name.
+
+    OSM query unions amenity=ranger_station with tourism=information+information=visitor_centre.
+    USFS ArcGIS EDW provides the administrative district/forest name (no key required).
+    USFS failure is soft — OSM data still returned.
+    """
+    overpass_query = f"""
+[out:json][timeout:25];
+(
+  nwr[amenity=ranger_station](around:50000,{float(lat)},{float(lon)});
+  nwr[tourism=information][information=visitor_centre](around:50000,{float(lat)},{float(lon)});
+);
+out center tags;
+"""
+    try:
+        with httpx.Client(timeout=35.0) as client:
+            resp = client.post(OVERPASS_URL, data={"data": overpass_query})
+            resp.raise_for_status()
+            elements = resp.json().get("elements", [])
+
+        stations = []
+        for el in elements:
+            tags = el.get("tags", {})
+            elat = el.get("lat") or (el.get("center") or {}).get("lat")
+            elon = el.get("lon") or (el.get("center") or {}).get("lon")
+            if elat is None or elon is None:
+                continue
+            stations.append(
+                {
+                    "name": tags.get("name", "Unknown station"),
+                    "lat": elat,
+                    "lon": elon,
+                    "distance_miles": round(_haversine_miles(lat, lon, elat, elon), 1),
+                    "phone": tags.get("phone"),
+                    "website": tags.get("website"),
+                }
+            )
+        stations.sort(key=lambda s: s["distance_miles"])
+
+        result: dict[str, Any] = {"stations": stations[:3]}
+
+        # USFS administrative district (soft — failure just omits district)
+        try:
+            with httpx.Client(timeout=20.0) as client:
+                usfs_resp = client.get(
+                    USFS_DISTRICTS_URL,
+                    params={
+                        "geometry": f"{float(lon)},{float(lat)}",
+                        "geometryType": "esriGeometryPoint",
+                        "inSR": "4326",
+                        "spatialRel": "esriSpatialRelIntersects",
+                        "outFields": "districtname,forestname,region",
+                        "f": "json",
+                        "returnGeometry": "false",
+                    },
+                )
+                usfs_resp.raise_for_status()
+                features = usfs_resp.json().get("features", [])
+                if features:
+                    attrs = features[0].get("attributes", {})
+                    result["admin_district"] = {
+                        "district_name": attrs.get("districtname"),
+                        "forest_name": attrs.get("forestname"),
+                        "region": attrs.get("region"),
+                    }
+        except Exception:
+            pass  # USFS failure is non-fatal
+
+        return result
+    except Exception as e:
+        return {"error": str(e), "note": "Ranger station lookup failed; check OSM Overpass."}
+
+
+def fetch_campgrounds(lat: float, lon: float) -> dict[str, Any]:
+    """Return established campgrounds within ~20 km via OSM Overpass.
+
+    Note: backcountry/high camps are NOT in any database — they come from
+    trip reports and route beta, not this fetcher.
+    """
+    query = f"""
+[out:json][timeout:25];
+nwr[tourism=camp_site](around:20000,{float(lat)},{float(lon)});
+out center tags;
+"""
+    try:
+        with httpx.Client(timeout=35.0) as client:
+            resp = client.post(OVERPASS_URL, data={"data": query})
+            resp.raise_for_status()
+            elements = resp.json().get("elements", [])
+
+        campgrounds = []
+        for el in elements:
+            tags = el.get("tags", {})
+            elat = el.get("lat") or (el.get("center") or {}).get("lat")
+            elon = el.get("lon") or (el.get("center") or {}).get("lon")
+            if elat is None or elon is None:
+                continue
+            campgrounds.append(
+                {
+                    "name": tags.get("name", "Unnamed campground"),
+                    "lat": elat,
+                    "lon": elon,
+                    "distance_miles": round(_haversine_miles(lat, lon, elat, elon), 1),
+                    "camp_type": tags.get("camp_type"),
+                    "backcountry": tags.get("backcountry"),
+                    "operator": tags.get("operator"),
+                }
+            )
+        campgrounds.sort(key=lambda c: c["distance_miles"])
+
+        return {
+            "campgrounds": campgrounds,
+            "note": (
+                "Established campgrounds only (OSM data). "
+                "Backcountry and high camps are not in any database — "
+                "extract from trip reports and route beta."
+            ),
+        }
+    except Exception as e:
+        return {"error": str(e), "note": "Campground lookup failed; check OSM Overpass."}
+
+
 def run_peakbagger_stats(peak_id: int) -> dict[str, Any]:
     """Run peakbagger-cli to get ascent statistics."""
     try:
@@ -298,16 +556,24 @@ def run_peakbagger_ascents(peak_id: int, within: str = "1y") -> dict[str, Any]:
 
 
 @click.command()
-@click.option("--coordinates", required=True, help="Coordinates as lat,lon")
+@click.option("--coordinates", required=True, help="Summit coordinates as lat,lon")
 @click.option("--elevation", required=True, type=float, help="Elevation in meters")
 @click.option("--peak-name", required=True, help="Peak name")
 @click.option("--peak-id", type=int, default=None, help="PeakBagger peak ID (optional)")
 @click.option("--date", default=None, help="Date as YYYY-MM-DD (default: today)")
-def cli(coordinates: str, elevation: float, peak_name: str, peak_id: int, date: str):
+@click.option("--trailhead", default=None, help="Trailhead coordinates as lat,lon (optional)")
+def cli(
+    coordinates: str,
+    elevation: float,
+    peak_name: str,
+    peak_id: int,
+    date: str,
+    trailhead: str,
+):
     """Fetch all conditions data for a peak.
 
-    Returns unified JSON with weather, air quality, daylight, and avalanche data.
-    Optionally fetches PeakBagger statistics if --peak-id is provided.
+    Returns unified JSON with weather, air quality, daylight, avalanche,
+    geodata (counties, hospital, ranger station, campgrounds), and PeakBagger data.
     """
     try:
         lat, lon = map(float, coordinates.split(","))
@@ -315,10 +581,19 @@ def cli(coordinates: str, elevation: float, peak_name: str, peak_id: int, date: 
         click.echo(json.dumps({"error": "Invalid coordinates format. Use lat,lon"}), err=True)
         sys.exit(1)
 
+    trailhead_coords: tuple[float, float] | None = None
+    if trailhead:
+        try:
+            th_lat, th_lon = map(float, trailhead.split(","))
+            trailhead_coords = (th_lat, th_lon)
+        except ValueError:
+            click.echo(json.dumps({"error": "Invalid --trailhead format. Use lat,lon"}), err=True)
+            sys.exit(1)
+
     date_str = date or datetime.now().strftime("%Y-%m-%d")
     gaps = []
 
-    # Fetch all data
+    # Existing fetchers
     weather = fetch_weather(lat, lon, elevation)
     if "error" in weather:
         gaps.append({"source": "Open-Meteo Weather", "reason": weather["error"]})
@@ -327,13 +602,29 @@ def cli(coordinates: str, elevation: float, peak_name: str, peak_id: int, date: 
     if "error" in air_quality:
         gaps.append({"source": "Open-Meteo Air Quality", "reason": air_quality["error"]})
 
-    # Pass timezone from weather API to daylight calculation
     tz_name = weather.get("timezone")
     daylight = fetch_daylight(lat, lon, date_str, tz_name)
     if "error" in daylight:
         gaps.append({"source": "Daylight calculation", "reason": daylight["error"]})
 
     avalanche = fetch_avalanche(lat, lon)
+
+    # Phase 1 geodata fetchers
+    counties = fetch_counties((lat, lon), trailhead_coords)
+    if "error" in counties:
+        gaps.append({"source": "FCC Counties", "reason": counties["error"]})
+
+    nearest_hospital = fetch_nearest_hospital(lat, lon)
+    if "error" in nearest_hospital:
+        gaps.append({"source": "OSM Nearest Hospital", "reason": nearest_hospital["error"]})
+
+    ranger_station = fetch_ranger_station(lat, lon)
+    if "error" in ranger_station:
+        gaps.append({"source": "OSM/USFS Ranger Station", "reason": ranger_station["error"]})
+
+    campgrounds = fetch_campgrounds(lat, lon)
+    if "error" in campgrounds:
+        gaps.append({"source": "OSM Campgrounds", "reason": campgrounds["error"]})
 
     # PeakBagger data (if peak_id provided)
     peakbagger = {}
@@ -355,6 +646,10 @@ def cli(coordinates: str, elevation: float, peak_name: str, peak_id: int, date: 
         "air_quality": air_quality,
         "daylight": daylight,
         "avalanche": avalanche,
+        "counties": counties,
+        "nearest_hospital": nearest_hospital,
+        "ranger_station": ranger_station,
+        "campgrounds": campgrounds,
         "peakbagger": peakbagger,
         "gaps": gaps,
     }

--- a/skills/route-researcher/tools/fetch_conditions.py
+++ b/skills/route-researcher/tools/fetch_conditions.py
@@ -55,7 +55,10 @@ def fetch_weather(lat: float, lon: float, elevation_m: float, days: int = 7) -> 
         "latitude": lat,
         "longitude": lon,
         "elevation": elevation_m,
-        "daily": "temperature_2m_max,temperature_2m_min,precipitation_sum,precipitation_probability_max,wind_speed_10m_max,weather_code",
+        "daily": (
+            "temperature_2m_max,temperature_2m_min,precipitation_sum,"
+            "precipitation_probability_max,wind_speed_10m_max,weather_code"
+        ),
         "hourly": "freezing_level_height",
         "timezone": "auto",
         "forecast_days": days,
@@ -596,7 +599,13 @@ def build_itinerary(
     from datetime import datetime, timedelta
 
     fmt_in = "%H:%M"
-    fmt_out = "%H:%M"
+
+    def _fmt(dt: datetime, ref: datetime) -> str:
+        """Format dt as HH:MM, appending ' (+1d)' when it falls on the next calendar day."""
+        s = dt.strftime("%H:%M")
+        if dt.date() > ref.date():
+            s += " (+1d)"
+        return s
 
     try:
         start_dt = datetime.strptime(start_time, fmt_in)
@@ -642,9 +651,9 @@ def build_itinerary(
 
     return {
         "start_time": start_time,
-        "summit_eta": summit_dt.strftime(fmt_out),
-        "turnaround_by": turnaround_dt.strftime(fmt_out),
-        "return_eta": return_dt.strftime(fmt_out),
+        "summit_eta": _fmt(summit_dt, start_dt),
+        "turnaround_by": _fmt(turnaround_dt, start_dt),
+        "return_eta": _fmt(return_dt, start_dt),
         "after_dark": after_dark,
         "dusk_cutoff": dusk_str,
         "total_hr": total_hr,
@@ -883,7 +892,11 @@ def cli(
     # Navigation bearings: needs 2+ waypoints
     if waypoints and len(waypoints) >= 2:
         try:
-            parsed = [tuple(map(float, w.split(","))) for w in waypoints]
+            parsed = [
+                (float(parts[0]), float(parts[1]))
+                for w in waypoints
+                if (parts := w.split(",")) and len(parts) >= 2
+            ]
             output["bearings"] = compute_bearings(parsed)
         except Exception as e:
             gaps.append({"source": "Navigation bearings", "reason": str(e)})

--- a/skills/route-researcher/tools/fetch_conditions.py
+++ b/skills/route-researcher/tools/fetch_conditions.py
@@ -6,9 +6,10 @@ Returns unified JSON matching the data contract for the route-researcher skill.
 """
 
 import json
+import math
 import subprocess
 import sys
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any
 
 import click
@@ -44,7 +45,7 @@ WEATHER_CODES = {
 PEAKBAGGER_CMD = [
     "uvx",
     "--from",
-    "peakbagger-cli>=1.10.0",
+    "git+https://github.com/dreamiurg/peakbagger-cli.git@v1.10.0",
     "peakbagger",
 ]
 
@@ -56,7 +57,7 @@ def fetch_weather(lat: float, lon: float, elevation_m: float, days: int = 7) -> 
         "longitude": lon,
         "elevation": elevation_m,
         "daily": (
-            "temperature_2m_max,temperature_2m_min,precipitation_sum,"
+            "temperature_2m_max,temperature_2m_min,"
             "precipitation_probability_max,wind_speed_10m_max,weather_code"
         ),
         "hourly": "freezing_level_height",
@@ -193,6 +194,8 @@ def fetch_daylight(
         import zoneinfo
 
         from astral import LocationInfo
+        from astral.sun import dawn as astral_dawn
+        from astral.sun import dusk as astral_dusk
         from astral.sun import sun
 
         date_obj = datetime.strptime(date_str, "%Y-%m-%d").date()
@@ -203,8 +206,6 @@ def fetch_daylight(
             tz = zoneinfo.ZoneInfo(tz_name) if tz_name else zoneinfo.ZoneInfo("UTC")
         except Exception:
             tz = zoneinfo.ZoneInfo("UTC")
-        from astral.sun import dawn as astral_dawn
-        from astral.sun import dusk as astral_dusk
 
         s = sun(location.observer, date=date_obj, tzinfo=tz)
 
@@ -292,8 +293,6 @@ def fetch_avalanche(lat: float, lon: float) -> dict[str, Any]:
 
 def _haversine_miles(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
     """Haversine distance in miles between two lat/lon points."""
-    import math
-
     R = 3958.8  # Earth radius in miles
     phi1, phi2 = math.radians(lat1), math.radians(lat2)
     dphi = math.radians(lat2 - lat1)
@@ -337,8 +336,10 @@ def fetch_counties(
     try:
         points = _sample_line(trailhead, summit, n_samples) if trailhead else [summit]
         seen: dict[str, dict] = {}
+        stale = 0  # consecutive points that added no new counties
         with httpx.Client(timeout=30.0) as client:
             for lat, lon in points:
+                prev_count = len(seen)
                 try:
                     resp = client.get(
                         FCC_AREA_URL,
@@ -356,7 +357,16 @@ def fetch_counties(
                                 "state_code": r.get("state_code"),
                             }
                 except Exception:
+                    stale += 1
+                    if stale >= 5:
+                        break
                     continue  # single-point failure is non-fatal
+                if len(seen) == prev_count:
+                    stale += 1
+                    if stale >= 5:
+                        break
+                else:
+                    stale = 0
 
         if not seen and points:
             return {
@@ -382,10 +392,28 @@ def fetch_counties(
         }
 
 
+def _osm_coords(el: dict) -> tuple[float | None, float | None]:
+    """Extract lat/lon from a node element or a way/relation with a center."""
+    elat = el["lat"] if "lat" in el else (el.get("center") or {}).get("lat")
+    elon = el["lon"] if "lon" in el else (el.get("center") or {}).get("lon")
+    return elat, elon
+
+
+def _overpass_query(query: str) -> list[dict]:
+    """POST query to Overpass API and return elements list.
+
+    Raises on network or HTTP error — callers must catch for graceful degradation.
+    """
+    with httpx.Client(timeout=35.0) as client:
+        resp = client.post(OVERPASS_URL, data={"data": query})
+        resp.raise_for_status()
+        return resp.json().get("elements", [])
+
+
 def fetch_nearest_hospital(lat: float, lon: float) -> dict[str, Any]:
     """Return nearest hospitals via OSM Overpass, sorted by distance.
 
-    Prefers emergency=yes / opening_hours=24/7 but does not require them.
+    Prefers emergency=yes (sorted first); does not require it.
     Returns top 3 results.
     """
     query = f"""
@@ -394,25 +422,17 @@ nwr[amenity=hospital](around:50000,{float(lat)},{float(lon)});
 out center tags;
 """
     try:
-        with httpx.Client(timeout=35.0) as client:
-            resp = client.post(OVERPASS_URL, data={"data": query})
-            resp.raise_for_status()
-            elements = resp.json().get("elements", [])
-
+        elements = _overpass_query(query)
         hospitals = []
         for el in elements:
             tags = el.get("tags", {})
-            elat = el.get("lat") or (el.get("center") or {}).get("lat")
-            elon = el.get("lon") or (el.get("center") or {}).get("lon")
+            elat, elon = _osm_coords(el)
             if elat is None or elon is None:
                 continue
             entry: dict[str, Any] = {
                 "name": tags.get("name", "Unknown hospital"),
-                "lat": elat,
-                "lon": elon,
                 "distance_miles": round(_haversine_miles(lat, lon, elat, elon), 1),
                 "emergency": tags.get("emergency"),
-                "opening_hours": tags.get("opening_hours"),
             }
             if "phone" in tags:
                 entry["phone"] = tags["phone"]
@@ -441,23 +461,16 @@ def fetch_ranger_station(lat: float, lon: float) -> dict[str, Any]:
 out center tags;
 """
     try:
-        with httpx.Client(timeout=35.0) as client:
-            resp = client.post(OVERPASS_URL, data={"data": overpass_query})
-            resp.raise_for_status()
-            elements = resp.json().get("elements", [])
-
+        elements = _overpass_query(overpass_query)
         stations = []
         for el in elements:
             tags = el.get("tags", {})
-            elat = el.get("lat") or (el.get("center") or {}).get("lat")
-            elon = el.get("lon") or (el.get("center") or {}).get("lon")
+            elat, elon = _osm_coords(el)
             if elat is None or elon is None:
                 continue
             stations.append(
                 {
                     "name": tags.get("name", "Unknown station"),
-                    "lat": elat,
-                    "lon": elon,
                     "distance_miles": round(_haversine_miles(lat, lon, elat, elon), 1),
                     "phone": tags.get("phone"),
                     "website": tags.get("website"),
@@ -500,7 +513,7 @@ out center tags;
 
 
 def fetch_campgrounds(lat: float, lon: float) -> dict[str, Any]:
-    """Return established campgrounds within ~20 km via OSM Overpass.
+    """Return established campgrounds within ~12 mi (~20 km) via OSM Overpass.
 
     Note: backcountry/high camps are NOT in any database — they come from
     trip reports and route beta, not this fetcher.
@@ -511,23 +524,16 @@ nwr[tourism=camp_site](around:20000,{float(lat)},{float(lon)});
 out center tags;
 """
     try:
-        with httpx.Client(timeout=35.0) as client:
-            resp = client.post(OVERPASS_URL, data={"data": query})
-            resp.raise_for_status()
-            elements = resp.json().get("elements", [])
-
+        elements = _overpass_query(query)
         campgrounds = []
         for el in elements:
             tags = el.get("tags", {})
-            elat = el.get("lat") or (el.get("center") or {}).get("lat")
-            elon = el.get("lon") or (el.get("center") or {}).get("lon")
+            elat, elon = _osm_coords(el)
             if elat is None or elon is None:
                 continue
             campgrounds.append(
                 {
                     "name": tags.get("name", "Unnamed campground"),
-                    "lat": elat,
-                    "lon": elon,
                     "distance_miles": round(_haversine_miles(lat, lon, elat, elon), 1),
                     "camp_type": tags.get("camp_type"),
                     "backcountry": tags.get("backcountry"),
@@ -555,7 +561,7 @@ def estimate_times(distance_mi: float, gain_ft: float) -> dict[str, Any]:
     Unroped: gain / 1000 ft/hr.
     Standard tiers use Naismith's rule variants.
     """
-    roped_by_distance = distance_mi / 1.0 if distance_mi else 0.0
+    roped_by_distance = distance_mi if distance_mi else 0.0  # 1 mph glacier pace
     roped_by_gain = gain_ft / 1000.0 if gain_ft else 0.0
     roped_hr = max(roped_by_distance, roped_by_gain)
     unroped_hr = gain_ft / 1000.0 if gain_ft else 0.0
@@ -596,8 +602,6 @@ def build_itinerary(
     Dusk is anchored to the start date (or day+1 when the dusk time-of-day is earlier
     than start time-of-day, e.g. a 23:00 start with 22:00 dusk).
     """
-    from datetime import datetime, timedelta
-
     fmt_in = "%H:%M"
 
     def _fmt(dt: datetime, ref: datetime) -> str:
@@ -614,9 +618,9 @@ def build_itinerary(
 
     times = estimate_times(distance_mi, gain_ft)
 
-    # Ascent: moderate pace; descent: fast pace (downhill)
+    # Ascent: moderate pace; descent: half of raw fast pace (downhill, unrounded)
     ascent_hr = times["moderate_hr"]
-    descent_hr = times["fast_hr"] * 0.5
+    descent_hr = (distance_mi / 3.5 + gain_ft / 2000) * 0.5  # raw formula avoids rounding error
     total_hr = round(ascent_hr + descent_hr, 1)
 
     summit_dt = start_dt + timedelta(hours=ascent_hr)
@@ -669,8 +673,6 @@ def compute_bearings(waypoints: list[tuple[float, float]]) -> dict[str, Any]:
 
     Each segment: bearing_deg (0–360), distance_mi, cumulative_distance_mi, from/to indices.
     """
-    import math as _math
-
     if len(waypoints) < 2:
         return {"segments": [], "total_distance_mi": 0.0}
 
@@ -682,12 +684,12 @@ def compute_bearings(waypoints: list[tuple[float, float]]) -> dict[str, Any]:
         lat2, lon2 = float(waypoints[i + 1][0]), float(waypoints[i + 1][1])
 
         # Forward azimuth (bearing) using spherical formula
-        phi1 = _math.radians(lat1)
-        phi2 = _math.radians(lat2)
-        dl = _math.radians(lon2 - lon1)
-        x = _math.sin(dl) * _math.cos(phi2)
-        y = _math.cos(phi1) * _math.sin(phi2) - _math.sin(phi1) * _math.cos(phi2) * _math.cos(dl)
-        bearing = (_math.degrees(_math.atan2(x, y)) + 360) % 360
+        phi1 = math.radians(lat1)
+        phi2 = math.radians(lat2)
+        dl = math.radians(lon2 - lon1)
+        x = math.sin(dl) * math.cos(phi2)
+        y = math.cos(phi1) * math.sin(phi2) - math.sin(phi1) * math.cos(phi2) * math.cos(dl)
+        bearing = (math.degrees(math.atan2(x, y)) + 360) % 360
 
         dist = _haversine_miles(lat1, lon1, lat2, lon2)
         cumulative += dist

--- a/skills/route-researcher/tools/fetch_conditions.py
+++ b/skills/route-researcher/tools/fetch_conditions.py
@@ -336,10 +336,9 @@ def fetch_counties(
     try:
         points = _sample_line(trailhead, summit, n_samples) if trailhead else [summit]
         seen: dict[str, dict] = {}
-        stale = 0  # consecutive points that added no new counties
+        errors = 0  # consecutive failed requests (API likely down)
         with httpx.Client(timeout=30.0) as client:
             for lat, lon in points:
-                prev_count = len(seen)
                 try:
                     resp = client.get(
                         FCC_AREA_URL,
@@ -356,17 +355,15 @@ def fetch_counties(
                                 "state_name": r.get("state_name"),
                                 "state_code": r.get("state_code"),
                             }
+                    errors = 0  # a successful request resets the failure counter
                 except Exception:
-                    stale += 1
-                    if stale >= 5:
-                        break
+                    errors += 1
+                    if errors >= 5:
+                        break  # API appears down; stop hammering it
                     continue  # single-point failure is non-fatal
-                if len(seen) == prev_count:
-                    stale += 1
-                    if stale >= 5:
-                        break
-                else:
-                    stale = 0
+                # Keep sampling every point on success — a route can re-enter a
+                # new county after a long stretch in one, so never early-exit on
+                # "no new county" (would miss later boundary crossings).
 
         if not seen and points:
             return {
@@ -908,7 +905,15 @@ def cli(
                 for w in waypoints
                 if (parts := w.split(",")) and len(parts) >= 2
             ]
-            output["bearings"] = compute_bearings(parsed)
+            if len(parsed) < 2:
+                gaps.append(
+                    {
+                        "source": "Navigation bearings",
+                        "reason": "Need at least 2 valid waypoints in lat,lon format.",
+                    }
+                )
+            else:
+                output["bearings"] = compute_bearings(parsed)
         except Exception as e:
             gaps.append({"source": "Navigation bearings", "reason": str(e)})
 

--- a/skills/route-researcher/tools/fetch_conditions.py
+++ b/skills/route-researcher/tools/fetch_conditions.py
@@ -399,12 +399,21 @@ def _osm_coords(el: dict) -> tuple[float | None, float | None]:
     return elat, elon
 
 
+_OVERPASS_HEADERS = {
+    "User-Agent": (
+        "claude-mountaineering-skills/route-researcher "
+        "(https://github.com/dreamiurg/claude-mountaineering-skills)"
+    ),
+    "Accept": "application/json",
+}
+
+
 def _overpass_query(query: str) -> list[dict]:
     """POST query to Overpass API and return elements list.
 
     Raises on network or HTTP error — callers must catch for graceful degradation.
     """
-    with httpx.Client(timeout=35.0) as client:
+    with httpx.Client(timeout=35.0, headers=_OVERPASS_HEADERS) as client:
         resp = client.post(OVERPASS_URL, data={"data": query})
         resp.raise_for_status()
         return resp.json().get("elements", [])

--- a/skills/route-researcher/tools/fetch_conditions.py
+++ b/skills/route-researcher/tools/fetch_conditions.py
@@ -200,25 +200,66 @@ def fetch_daylight(
             tz = zoneinfo.ZoneInfo(tz_name) if tz_name else zoneinfo.ZoneInfo("UTC")
         except Exception:
             tz = zoneinfo.ZoneInfo("UTC")
+        from astral.sun import dawn as astral_dawn
+        from astral.sun import dusk as astral_dusk
+
         s = sun(location.observer, date=date_obj, tzinfo=tz)
 
         sunrise = s["sunrise"]
         sunset = s["sunset"]
-        dawn = s["dawn"]  # Civil twilight
+        civil_dawn = s["dawn"]  # −6° depression
+        civil_dusk = s["dusk"]  # −6° depression
+
+        fmt = "%-I:%M %p"
+
+        def _try_twilight(fn, depression):
+            """Return formatted time or None if sun never reaches that depression."""
+            try:
+                t = fn(location.observer, date=date_obj, depression=depression, tzinfo=tz)
+                return t.strftime(fmt)
+            except Exception:
+                return None
+
+        nautical_dawn = _try_twilight(astral_dawn, 12)
+        nautical_dusk = _try_twilight(astral_dusk, 12)
+        astronomical_dawn = _try_twilight(astral_dawn, 18)
+        astronomical_dusk = _try_twilight(astral_dusk, 18)
 
         daylight = sunset - sunrise
         daylight_hours = daylight.total_seconds() / 3600
 
         tz_label = tz_name if tz_name else "UTC"
         return {
-            "sunrise": sunrise.strftime("%-I:%M %p"),
-            "sunset": sunset.strftime("%-I:%M %p"),
-            "civil_twilight": dawn.strftime("%-I:%M %p"),
+            "astronomical_dawn": astronomical_dawn,
+            "nautical_dawn": nautical_dawn,
+            "civil_twilight": civil_dawn.strftime(fmt),
+            "sunrise": sunrise.strftime(fmt),
+            "sunset": sunset.strftime(fmt),
+            "civil_dusk": civil_dusk.strftime(fmt),
+            "nautical_dusk": nautical_dusk,
+            "astronomical_dusk": astronomical_dusk,
             "daylight_hours": round(daylight_hours, 1),
             "timezone": tz_label,
         }
     except Exception as e:
         return {"error": str(e)}
+
+
+def _enrich_forecast_snow_line(forecast: list[dict], summit_elevation_ft: float) -> None:
+    """Add snow_line_note and near_summit fields to each forecast day (in-place)."""
+    for day in forecast:
+        fl = day.get("freezing_level_ft")
+        if fl is not None:
+            note = f"Snow line ~{fl:,} ft (freezing level)"
+            diff = abs(summit_elevation_ft - fl)
+            near = diff <= 2000
+            if near:
+                note += f" — within {int(diff):,} ft of summit"
+        else:
+            note = "Freezing level data unavailable"
+            near = False
+        day["snow_line_note"] = note
+        day["near_summit"] = near
 
 
 def fetch_avalanche(lat: float, lon: float) -> dict[str, Any]:
@@ -504,6 +545,37 @@ out center tags;
         return {"error": str(e), "note": "Campground lookup failed; check OSM Overpass."}
 
 
+def estimate_times(distance_mi: float, gain_ft: float) -> dict[str, Any]:
+    """Estimate travel times using roped/unroped and standard pacing models.
+
+    Roped (glacier): slower of distance/1.0 mph or gain/1000 ft/hr.
+    Unroped: gain / 1000 ft/hr.
+    Standard tiers use Naismith's rule variants.
+    """
+    roped_by_distance = distance_mi / 1.0 if distance_mi else 0.0
+    roped_by_gain = gain_ft / 1000.0 if gain_ft else 0.0
+    roped_hr = max(roped_by_distance, roped_by_gain)
+    unroped_hr = gain_ft / 1000.0 if gain_ft else 0.0
+
+    # Standard pacing tiers (distance / pace + gain adjustment)
+    fast_hr = round(distance_mi / 3.5 + gain_ft / 2000, 1)
+    moderate_hr = round(distance_mi / 2.5 + gain_ft / 1500, 1)
+    leisurely_hr = round(distance_mi / 2.0 + gain_ft / 1000, 1)
+
+    return {
+        "roped_hr": round(roped_hr, 1),
+        "unroped_hr": round(unroped_hr, 1),
+        "fast_hr": fast_hr,
+        "moderate_hr": moderate_hr,
+        "leisurely_hr": leisurely_hr,
+        "note": (
+            "Roped: ~1 mi/hr on glacier (slower of distance or gain limit). "
+            "Unroped: ~1,000 ft/hr gain. "
+            "Standard tiers use Naismith-variant pacing."
+        ),
+    }
+
+
 def run_peakbagger_stats(peak_id: int) -> dict[str, Any]:
     """Run peakbagger-cli to get ascent statistics."""
     try:
@@ -562,6 +634,15 @@ def run_peakbagger_ascents(peak_id: int, within: str = "1y") -> dict[str, Any]:
 @click.option("--peak-id", type=int, default=None, help="PeakBagger peak ID (optional)")
 @click.option("--date", default=None, help="Date as YYYY-MM-DD (default: today)")
 @click.option("--trailhead", default=None, help="Trailhead coordinates as lat,lon (optional)")
+@click.option(
+    "--distance-mi",
+    type=float,
+    default=None,
+    help="Round-trip distance in miles (for time estimates)",
+)
+@click.option(
+    "--gain-ft", type=float, default=None, help="Total elevation gain in feet (for time estimates)"
+)
 def cli(
     coordinates: str,
     elevation: float,
@@ -569,6 +650,8 @@ def cli(
     peak_id: int,
     date: str,
     trailhead: str,
+    distance_mi: float,
+    gain_ft: float,
 ):
     """Fetch all conditions data for a peak.
 
@@ -593,10 +676,14 @@ def cli(
     date_str = date or datetime.now().strftime("%Y-%m-%d")
     gaps = []
 
+    summit_elevation_ft = round(elevation * 3.28084)
+
     # Existing fetchers
     weather = fetch_weather(lat, lon, elevation)
     if "error" in weather:
         gaps.append({"source": "Open-Meteo Weather", "reason": weather["error"]})
+    else:
+        _enrich_forecast_snow_line(weather.get("forecast", []), summit_elevation_ft)
 
     air_quality = fetch_air_quality(lat, lon)
     if "error" in air_quality:
@@ -641,7 +728,7 @@ def cli(
         else:
             peakbagger["ascents"] = ascents
 
-    output = {
+    output: dict[str, Any] = {
         "weather": weather,
         "air_quality": air_quality,
         "daylight": daylight,
@@ -653,6 +740,9 @@ def cli(
         "peakbagger": peakbagger,
         "gaps": gaps,
     }
+
+    if distance_mi is not None and gain_ft is not None:
+        output["time_estimates"] = estimate_times(distance_mi, gain_ft)
 
     click.echo(json.dumps(output, indent=2))
 

--- a/skills/route-researcher/tools/pyproject.toml
+++ b/skills/route-researcher/tools/pyproject.toml
@@ -8,10 +8,10 @@ dependencies = [
     "httpx>=0.27.0",
     "rich>=13.0.0",
     "astral>=3.2",
-    "cloudscraper>=1.2.71",
+    "patchright>=1.49.0",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = ["pytest>=8.0.0"]
 
 [tool.hatch.build.targets.wheel]

--- a/skills/route-researcher/tools/pyproject.toml
+++ b/skills/route-researcher/tools/pyproject.toml
@@ -6,7 +6,6 @@ requires-python = ">=3.11"
 dependencies = [
     "click>=8.1.0",
     "httpx>=0.27.0",
-    "rich>=13.0.0",
     "astral>=3.2",
     "patchright>=1.49.0",
 ]

--- a/skills/route-researcher/tools/test_cloudscrape.py
+++ b/skills/route-researcher/tools/test_cloudscrape.py
@@ -1,0 +1,145 @@
+"""Tests for cloudscrape.py
+
+Unit tests with mocked HTTP / render path — no real browser launched.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+from cloudscrape import cli
+
+
+class TestDefaultPath:
+    """Tests for the default (non-render) HTTP fetch path."""
+
+    def test_success_returns_html_to_stdout(self):
+        """Successful fetch prints HTML to stdout and exits 0."""
+        runner = CliRunner()
+        mock_response = MagicMock()
+        mock_response.text = "<html><body>Hello</body></html>"
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("cloudscrape.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=False)
+            mock_client.get.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            result = runner.invoke(cli, ["https://example.com"])
+
+        assert result.exit_code == 0
+        assert "<html>" in result.output
+
+    def test_network_error_exits_0_with_note(self):
+        """Network failure exits 0 (graceful degradation) with a JSON note."""
+        runner = CliRunner()
+
+        with patch("cloudscrape.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=False)
+            mock_client.get.side_effect = Exception("Connection refused")
+            mock_client_cls.return_value = mock_client
+
+            result = runner.invoke(cli, ["https://example.com"])
+
+        assert result.exit_code == 0
+        # Should output a JSON error note (to stdout or stderr — either is fine per contract)
+        # At minimum the process must not crash with exit code != 0
+        data = json.loads(result.output)
+        assert "error" in data or "note" in data
+
+    def test_http_error_exits_0_with_note(self):
+        """HTTP 4xx/5xx exits 0 (graceful degradation) with a JSON note."""
+        import httpx
+
+        runner = CliRunner()
+
+        with patch("cloudscrape.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=False)
+            mock_response = MagicMock()
+            mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+                "403 Forbidden",
+                request=MagicMock(),
+                response=MagicMock(status_code=403),
+            )
+            mock_client.get.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            result = runner.invoke(cli, ["https://example.com"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "error" in data or "note" in data
+
+
+class TestRenderPath:
+    """Tests for the --render Patchright-backed path."""
+
+    def test_render_flag_routes_to_render_path(self):
+        """--render flag uses the render path (not plain HTTP)."""
+        runner = CliRunner()
+
+        with patch("cloudscrape._fetch_with_render") as mock_render:
+            mock_render.return_value = "<html>rendered</html>"
+            result = runner.invoke(cli, ["https://example.com", "--render"])
+
+        mock_render.assert_called_once()
+        assert result.exit_code == 0
+        assert "rendered" in result.output
+
+    def test_render_failure_exits_0_with_note(self):
+        """Render path failure exits 0 (graceful degradation) with a JSON note."""
+        runner = CliRunner()
+
+        with patch("cloudscrape._fetch_with_render") as mock_render:
+            mock_render.side_effect = Exception("Patchright not available")
+            result = runner.invoke(cli, ["https://example.com", "--render"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "error" in data or "note" in data
+
+    def test_render_patchright_import_error_exits_0(self):
+        """If patchright is not installed, exits 0 with a JSON note."""
+        runner = CliRunner()
+
+        with patch("cloudscrape._fetch_with_render") as mock_render:
+            mock_render.side_effect = ImportError("No module named 'patchright'")
+            result = runner.invoke(cli, ["https://example.com", "--render"])
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "error" in data or "note" in data
+
+
+class TestCLIContract:
+    """Tests that verify the documented CLI contract is preserved."""
+
+    def test_url_is_required_positional_argument(self):
+        """URL is a required positional argument; omitting it exits non-zero."""
+        runner = CliRunner()
+        result = runner.invoke(cli, [])
+        assert result.exit_code != 0
+
+    def test_timeout_option_accepted(self):
+        """--timeout option is accepted without error."""
+        runner = CliRunner()
+        mock_response = MagicMock()
+        mock_response.text = "<html/>"
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("cloudscrape.httpx.Client") as mock_client_cls:
+            mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=False)
+            mock_client.get.return_value = mock_response
+            mock_client_cls.return_value = mock_client
+
+            result = runner.invoke(cli, ["https://example.com", "--timeout", "60"])
+
+        assert result.exit_code == 0

--- a/skills/route-researcher/tools/test_cloudscrape.py
+++ b/skills/route-researcher/tools/test_cloudscrape.py
@@ -92,6 +92,26 @@ class TestRenderPath:
         assert result.exit_code == 0
         assert "rendered" in result.output
 
+    def test_render_forwards_default_timeout(self):
+        """--render passes the default timeout (30) to _fetch_with_render."""
+        runner = CliRunner()
+
+        with patch("cloudscrape._fetch_with_render") as mock_render:
+            mock_render.return_value = "<html/>"
+            runner.invoke(cli, ["https://example.com", "--render"])
+
+        mock_render.assert_called_once_with("https://example.com", 30)
+
+    def test_render_forwards_custom_timeout(self):
+        """--render --timeout 60 passes 60 to _fetch_with_render."""
+        runner = CliRunner()
+
+        with patch("cloudscrape._fetch_with_render") as mock_render:
+            mock_render.return_value = "<html/>"
+            runner.invoke(cli, ["https://example.com", "--render", "--timeout", "60"])
+
+        mock_render.assert_called_once_with("https://example.com", 60)
+
     def test_render_failure_exits_0_with_note(self):
         """Render path failure exits 0 (graceful degradation) with a JSON note."""
         runner = CliRunner()

--- a/skills/route-researcher/tools/test_geodata_fetchers.py
+++ b/skills/route-researcher/tools/test_geodata_fetchers.py
@@ -116,6 +116,35 @@ class TestFetchCounties:
         assert "counties" in result
         assert result["counties"] == []
 
+    def test_early_exit_after_five_stale_points(self):
+        """With 25 sample points all returning the same county, stops after 1+5=6 calls.
+
+        First call adds the county (stale resets to 0); next 5 calls add nothing
+        (stale reaches 5) → break.  Total: ≤6 GET calls, not 25.
+        """
+        with patch("fetch_conditions.httpx.Client") as mock_cls:
+            mock_client = _mock_httpx_get(self.FCC_RESPONSE)
+            mock_cls.return_value = mock_client
+            fetch_counties((47.44, -121.41), (48.77, -121.81), n_samples=25)
+
+        assert mock_client.get.call_count <= 6
+
+    def test_early_exit_after_five_consecutive_errors(self):
+        """Five consecutive per-point network errors trigger the stale early-exit.
+
+        A fully-down FCC API must not cause 25 × 30s timeouts.
+        """
+        with patch("fetch_conditions.httpx.Client") as mock_cls:
+            mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=False)
+            mock_client.get.side_effect = Exception("Connection refused")
+            mock_cls.return_value = mock_client
+
+            fetch_counties((47.44, -121.41), (48.77, -121.81), n_samples=25)
+
+        assert mock_client.get.call_count <= 7
+
 
 # ---------------------------------------------------------------------------
 # fetch_nearest_hospital
@@ -159,8 +188,6 @@ class TestFetchNearestHospital:
         assert len(result["hospitals"]) >= 1
         h = result["hospitals"][0]
         assert "name" in h
-        assert "lat" in h
-        assert "lon" in h
         assert "distance_miles" in h
 
     def test_prefers_emergency_yes(self):
@@ -375,8 +402,6 @@ class TestFetchCampgrounds:
         assert len(result["campgrounds"]) >= 1
         c = result["campgrounds"][0]
         assert "name" in c
-        assert "lat" in c
-        assert "lon" in c
         assert "distance_miles" in c
 
     def test_backcountry_gap_noted(self):

--- a/skills/route-researcher/tools/test_geodata_fetchers.py
+++ b/skills/route-researcher/tools/test_geodata_fetchers.py
@@ -7,6 +7,7 @@ import json
 from unittest.mock import MagicMock, patch
 
 from fetch_conditions import (
+    _OVERPASS_HEADERS,
     fetch_campgrounds,
     fetch_counties,
     fetch_nearest_hospital,
@@ -237,6 +238,28 @@ class TestFetchNearestHospital:
 
         assert "hospitals" in result
         assert result["hospitals"] == []
+
+
+class TestOverpassHeaders:
+    """_OVERPASS_HEADERS sent on every Overpass POST (prevents 406 from overpass-api.de)."""
+
+    def test_overpass_headers_has_user_agent(self):
+        """_OVERPASS_HEADERS must include a User-Agent identifying this project."""
+        assert "User-Agent" in _OVERPASS_HEADERS
+        assert "claude-mountaineering-skills" in _OVERPASS_HEADERS["User-Agent"]
+
+    def test_overpass_headers_has_accept_json(self):
+        """_OVERPASS_HEADERS must include Accept: application/json."""
+        assert _OVERPASS_HEADERS.get("Accept") == "application/json"
+
+    def test_hospital_query_sends_overpass_headers(self):
+        """fetch_nearest_hospital passes _OVERPASS_HEADERS to httpx.Client constructor."""
+        with patch("fetch_conditions.httpx.Client") as mock_cls:
+            mock_cls.return_value = _mock_httpx_post({"elements": []})
+            fetch_nearest_hospital(48.77, -121.81)
+
+        _, kwargs = mock_cls.call_args
+        assert kwargs.get("headers") == _OVERPASS_HEADERS
 
 
 # ---------------------------------------------------------------------------

--- a/skills/route-researcher/tools/test_geodata_fetchers.py
+++ b/skills/route-researcher/tools/test_geodata_fetchers.py
@@ -117,18 +117,16 @@ class TestFetchCounties:
         assert "counties" in result
         assert result["counties"] == []
 
-    def test_early_exit_after_five_stale_points(self):
-        """With 25 sample points all returning the same county, stops after 1+5=6 calls.
-
-        First call adds the county (stale resets to 0); next 5 calls add nothing
-        (stale reaches 5) → break.  Total: ≤6 GET calls, not 25.
+    def test_scans_all_points_on_success(self):
+        """Same-county successes must NOT early-exit — a route can re-enter a new
+        county after a long stretch, so every sample point is queried.
         """
         with patch("fetch_conditions.httpx.Client") as mock_cls:
             mock_client = _mock_httpx_get(self.FCC_RESPONSE)
             mock_cls.return_value = mock_client
             fetch_counties((47.44, -121.41), (48.77, -121.81), n_samples=25)
 
-        assert mock_client.get.call_count <= 6
+        assert mock_client.get.call_count == 25
 
     def test_early_exit_after_five_consecutive_errors(self):
         """Five consecutive per-point network errors trigger the stale early-exit.

--- a/skills/route-researcher/tools/test_geodata_fetchers.py
+++ b/skills/route-researcher/tools/test_geodata_fetchers.py
@@ -1,0 +1,534 @@
+"""Unit tests for Phase 1 geodata fetchers in fetch_conditions.py.
+
+All HTTP calls are mocked — no real network access required.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from fetch_conditions import (
+    fetch_campgrounds,
+    fetch_counties,
+    fetch_nearest_hospital,
+    fetch_ranger_station,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_httpx_post(json_body: dict) -> MagicMock:
+    """Return a context-manager mock for httpx.Client that returns json_body on .post()."""
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = json_body
+
+    mock_client = MagicMock()
+    mock_client.__enter__ = MagicMock(return_value=mock_client)
+    mock_client.__exit__ = MagicMock(return_value=False)
+    mock_client.post.return_value = mock_response
+    return mock_client
+
+
+def _mock_httpx_get(json_body: dict) -> MagicMock:
+    """Return a context-manager mock for httpx.Client that returns json_body on .get()."""
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = json_body
+
+    mock_client = MagicMock()
+    mock_client.__enter__ = MagicMock(return_value=mock_client)
+    mock_client.__exit__ = MagicMock(return_value=False)
+    mock_client.get.return_value = mock_response
+    return mock_client
+
+
+# ---------------------------------------------------------------------------
+# fetch_counties
+# ---------------------------------------------------------------------------
+
+
+class TestFetchCounties:
+    FCC_RESPONSE = {
+        "results": [
+            {
+                "county_name": "King County",
+                "county_fips": "53033",
+                "state_name": "Washington",
+                "state_code": "WA",
+            }
+        ]
+    }
+
+    def test_happy_path_summit_only_returns_county(self):
+        """With only summit coords, returns the summit county."""
+        with patch("fetch_conditions.httpx.Client") as mock_cls:
+            mock_cls.return_value = _mock_httpx_get(self.FCC_RESPONSE)
+            result = fetch_counties((48.77, -121.81), None)
+
+        assert "counties" in result
+        assert len(result["counties"]) >= 1
+        county = result["counties"][0]
+        assert county["county_name"] == "King County"
+        assert county["county_fips"] == "53033"
+        assert county["state_name"] == "Washington"
+
+    def test_happy_path_with_trailhead_samples_line(self):
+        """With trailhead + summit, samples multiple points along the line."""
+        with patch("fetch_conditions.httpx.Client") as mock_cls:
+            mock_cls.return_value = _mock_httpx_get(self.FCC_RESPONSE)
+            result = fetch_counties((47.44, -121.41), (48.77, -121.81))
+
+        assert "counties" in result
+        assert result["sampled"] is True
+        assert result["sample_points"] == 25
+
+    def test_deduplication_by_fips(self):
+        """Duplicate FIPS codes across sampled points are deduplicated."""
+        with patch("fetch_conditions.httpx.Client") as mock_cls:
+            mock_cls.return_value = _mock_httpx_get(self.FCC_RESPONSE)
+            result = fetch_counties((47.44, -121.41), (48.77, -121.81))
+
+        fips_list = [c["county_fips"] for c in result["counties"]]
+        assert len(fips_list) == len(set(fips_list)), "Duplicate FIPS found"
+
+    def test_network_error_returns_error_dict(self):
+        """Network failure returns a dict with error key (no exception raised)."""
+        with patch("fetch_conditions.httpx.Client") as mock_cls:
+            mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=False)
+            mock_client.get.side_effect = Exception("Connection refused")
+            mock_cls.return_value = mock_client
+
+            result = fetch_counties((48.77, -121.81), None)
+
+        assert "error" in result
+
+    def test_empty_results_handled(self):
+        """Empty FCC results list handled without error."""
+        empty = {"results": []}
+        with patch("fetch_conditions.httpx.Client") as mock_cls:
+            mock_cls.return_value = _mock_httpx_get(empty)
+            result = fetch_counties((48.77, -121.81), None)
+
+        assert "counties" in result
+        assert result["counties"] == []
+
+
+# ---------------------------------------------------------------------------
+# fetch_nearest_hospital
+# ---------------------------------------------------------------------------
+
+OVERPASS_HOSPITAL_RESPONSE = {
+    "elements": [
+        {
+            "type": "node",
+            "id": 1,
+            "lat": 48.42,
+            "lon": -122.33,
+            "tags": {
+                "name": "PeaceHealth St. Joseph",
+                "amenity": "hospital",
+                "emergency": "yes",
+                "phone": "+1-360-734-5400",
+            },
+        },
+        {
+            "type": "way",
+            "id": 2,
+            "center": {"lat": 48.51, "lon": -122.11},
+            "tags": {
+                "name": "Island Hospital",
+                "amenity": "hospital",
+            },
+        },
+    ]
+}
+
+
+class TestFetchNearestHospital:
+    def test_happy_path_returns_top_hospitals(self):
+        """Returns list of hospitals with required fields."""
+        with patch("fetch_conditions.httpx.Client") as mock_cls:
+            mock_cls.return_value = _mock_httpx_post(OVERPASS_HOSPITAL_RESPONSE)
+            result = fetch_nearest_hospital(48.77, -121.81)
+
+        assert "hospitals" in result
+        assert len(result["hospitals"]) >= 1
+        h = result["hospitals"][0]
+        assert "name" in h
+        assert "lat" in h
+        assert "lon" in h
+        assert "distance_miles" in h
+
+    def test_prefers_emergency_yes(self):
+        """Hospital with emergency=yes is ranked first."""
+        with patch("fetch_conditions.httpx.Client") as mock_cls:
+            mock_cls.return_value = _mock_httpx_post(OVERPASS_HOSPITAL_RESPONSE)
+            result = fetch_nearest_hospital(48.77, -121.81)
+
+        assert result["hospitals"][0]["name"] == "PeaceHealth St. Joseph"
+
+    def test_way_element_uses_center(self):
+        """Way elements use the center lat/lon."""
+        with patch("fetch_conditions.httpx.Client") as mock_cls:
+            mock_cls.return_value = _mock_httpx_post(OVERPASS_HOSPITAL_RESPONSE)
+            result = fetch_nearest_hospital(48.77, -121.81)
+
+        names = [h["name"] for h in result["hospitals"]]
+        assert "Island Hospital" in names
+
+    def test_phone_included_when_present(self):
+        """Phone number is included when available in tags."""
+        with patch("fetch_conditions.httpx.Client") as mock_cls:
+            mock_cls.return_value = _mock_httpx_post(OVERPASS_HOSPITAL_RESPONSE)
+            result = fetch_nearest_hospital(48.77, -121.81)
+
+        peace = next(h for h in result["hospitals"] if h["name"] == "PeaceHealth St. Joseph")
+        assert peace.get("phone") == "+1-360-734-5400"
+
+    def test_network_error_returns_error_dict(self):
+        """Network failure returns error dict without raising."""
+        with patch("fetch_conditions.httpx.Client") as mock_cls:
+            mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=False)
+            mock_client.post.side_effect = Exception("Timeout")
+            mock_cls.return_value = mock_client
+
+            result = fetch_nearest_hospital(48.77, -121.81)
+
+        assert "error" in result
+
+    def test_empty_elements_handled(self):
+        """Empty Overpass result handled without error."""
+        with patch("fetch_conditions.httpx.Client") as mock_cls:
+            mock_cls.return_value = _mock_httpx_post({"elements": []})
+            result = fetch_nearest_hospital(48.77, -121.81)
+
+        assert "hospitals" in result
+        assert result["hospitals"] == []
+
+
+# ---------------------------------------------------------------------------
+# fetch_ranger_station
+# ---------------------------------------------------------------------------
+
+OVERPASS_RANGER_RESPONSE = {
+    "elements": [
+        {
+            "type": "node",
+            "id": 10,
+            "lat": 48.65,
+            "lon": -121.95,
+            "tags": {
+                "name": "Mt Baker Ranger District Office",
+                "amenity": "ranger_station",
+            },
+        }
+    ]
+}
+
+USFS_DISTRICT_RESPONSE = {
+    "features": [
+        {
+            "attributes": {
+                "districtname": "Mt Baker Ranger District",
+                "forestname": "Mt Baker-Snoqualmie National Forest",
+                "region": "R6",
+            }
+        }
+    ]
+}
+
+USFS_EMPTY_RESPONSE: dict[str, list] = {"features": []}
+
+
+class TestFetchRangerStation:
+    def test_happy_path_returns_station_and_district(self):
+        """Returns OSM station plus USFS administrative district."""
+
+        def _get_side_effect(url, **kwargs):
+            mock_resp = MagicMock()
+            mock_resp.raise_for_status = MagicMock()
+            if "arcx" in url or "fs.usda.gov" in url:
+                mock_resp.json.return_value = USFS_DISTRICT_RESPONSE
+            else:
+                mock_resp.json.return_value = USFS_EMPTY_RESPONSE
+            return mock_resp
+
+        with patch("fetch_conditions.httpx.Client") as mock_cls:
+            mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=False)
+            mock_client.post.return_value = MagicMock(
+                raise_for_status=MagicMock(),
+                json=MagicMock(return_value=OVERPASS_RANGER_RESPONSE),
+            )
+            mock_client.get.side_effect = _get_side_effect
+            mock_cls.return_value = mock_client
+
+            result = fetch_ranger_station(48.77, -121.81)
+
+        assert "stations" in result
+        assert "admin_district" in result
+
+    def test_usfs_failure_still_returns_osm_data(self):
+        """USFS ArcGIS failure is soft — OSM data still returned."""
+        with patch("fetch_conditions.httpx.Client") as mock_cls:
+            mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=False)
+            mock_client.post.return_value = MagicMock(
+                raise_for_status=MagicMock(),
+                json=MagicMock(return_value=OVERPASS_RANGER_RESPONSE),
+            )
+            mock_client.get.side_effect = Exception("USFS down")
+            mock_cls.return_value = mock_client
+
+            result = fetch_ranger_station(48.77, -121.81)
+
+        # USFS failure is soft: no error key, OSM stations still present
+        assert "error" not in result
+        assert "stations" in result
+
+    def test_network_error_returns_error_dict(self):
+        """Full network failure returns error dict without raising."""
+        with patch("fetch_conditions.httpx.Client") as mock_cls:
+            mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=False)
+            mock_client.post.side_effect = Exception("Connection refused")
+            mock_client.get.side_effect = Exception("Connection refused")
+            mock_cls.return_value = mock_client
+
+            result = fetch_ranger_station(48.77, -121.81)
+
+        assert "error" in result
+
+    def test_empty_osm_still_returns_district(self):
+        """Empty OSM result still tries USFS district lookup."""
+
+        def _get_side_effect(url, **kwargs):
+            mock_resp = MagicMock()
+            mock_resp.raise_for_status = MagicMock()
+            mock_resp.json.return_value = USFS_DISTRICT_RESPONSE
+            return mock_resp
+
+        with patch("fetch_conditions.httpx.Client") as mock_cls:
+            mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=False)
+            mock_client.post.return_value = MagicMock(
+                raise_for_status=MagicMock(),
+                json=MagicMock(return_value={"elements": []}),
+            )
+            mock_client.get.side_effect = _get_side_effect
+            mock_cls.return_value = mock_client
+
+            result = fetch_ranger_station(48.77, -121.81)
+
+        assert "stations" in result
+        assert "admin_district" in result
+
+
+# ---------------------------------------------------------------------------
+# fetch_campgrounds
+# ---------------------------------------------------------------------------
+
+OVERPASS_CAMPGROUND_RESPONSE = {
+    "elements": [
+        {
+            "type": "node",
+            "id": 20,
+            "lat": 48.70,
+            "lon": -121.85,
+            "tags": {
+                "name": "Douglas Fir Campground",
+                "tourism": "camp_site",
+                "camp_type": "established",
+            },
+        },
+        {
+            "type": "way",
+            "id": 21,
+            "center": {"lat": 48.68, "lon": -121.80},
+            "tags": {
+                "name": "Horseshoe Cove Campground",
+                "tourism": "camp_site",
+            },
+        },
+    ]
+}
+
+
+class TestFetchCampgrounds:
+    def test_happy_path_returns_campgrounds(self):
+        """Returns list of campgrounds with name, coords, distance."""
+        with patch("fetch_conditions.httpx.Client") as mock_cls:
+            mock_cls.return_value = _mock_httpx_post(OVERPASS_CAMPGROUND_RESPONSE)
+            result = fetch_campgrounds(48.77, -121.81)
+
+        assert "campgrounds" in result
+        assert len(result["campgrounds"]) >= 1
+        c = result["campgrounds"][0]
+        assert "name" in c
+        assert "lat" in c
+        assert "lon" in c
+        assert "distance_miles" in c
+
+    def test_backcountry_gap_noted(self):
+        """Result includes a note that backcountry camps are not covered."""
+        with patch("fetch_conditions.httpx.Client") as mock_cls:
+            mock_cls.return_value = _mock_httpx_post(OVERPASS_CAMPGROUND_RESPONSE)
+            result = fetch_campgrounds(48.77, -121.81)
+
+        note = result.get("note", "") + json.dumps(result)
+        assert "backcountry" in note.lower() or "trip report" in note.lower()
+
+    def test_way_element_uses_center(self):
+        """Way elements use the center lat/lon."""
+        with patch("fetch_conditions.httpx.Client") as mock_cls:
+            mock_cls.return_value = _mock_httpx_post(OVERPASS_CAMPGROUND_RESPONSE)
+            result = fetch_campgrounds(48.77, -121.81)
+
+        names = [c["name"] for c in result["campgrounds"]]
+        assert "Horseshoe Cove Campground" in names
+
+    def test_network_error_returns_error_dict(self):
+        """Network failure returns error dict without raising."""
+        with patch("fetch_conditions.httpx.Client") as mock_cls:
+            mock_client = MagicMock()
+            mock_client.__enter__ = MagicMock(return_value=mock_client)
+            mock_client.__exit__ = MagicMock(return_value=False)
+            mock_client.post.side_effect = Exception("Timeout")
+            mock_cls.return_value = mock_client
+
+            result = fetch_campgrounds(48.77, -121.81)
+
+        assert "error" in result
+
+    def test_empty_elements_handled(self):
+        """Empty Overpass result handled without error."""
+        with patch("fetch_conditions.httpx.Client") as mock_cls:
+            mock_cls.return_value = _mock_httpx_post({"elements": []})
+            result = fetch_campgrounds(48.77, -121.81)
+
+        assert "campgrounds" in result
+        assert result["campgrounds"] == []
+
+
+# ---------------------------------------------------------------------------
+# CLI integration — new output keys wired into cli()
+# ---------------------------------------------------------------------------
+
+
+class TestCliOutputKeys:
+    """Verify the new keys appear in cli() output dict."""
+
+    def test_output_contains_new_geodata_keys(self):
+        """cli() output dict includes counties, nearest_hospital, ranger_station, campgrounds."""
+        from click.testing import CliRunner
+        from fetch_conditions import cli
+
+        runner = CliRunner()
+
+        # Patch all 4 new fetchers to return minimal valid dicts
+        with (
+            patch("fetch_conditions.fetch_counties", return_value={"counties": []}),
+            patch("fetch_conditions.fetch_nearest_hospital", return_value={"hospitals": []}),
+            patch("fetch_conditions.fetch_ranger_station", return_value={"stations": []}),
+            patch("fetch_conditions.fetch_campgrounds", return_value={"campgrounds": []}),
+            patch("fetch_conditions.fetch_weather", return_value={"forecast": []}),
+            patch("fetch_conditions.fetch_air_quality", return_value={"rating": "good"}),
+            patch("fetch_conditions.fetch_daylight", return_value={"sunrise": "6:00 AM"}),
+            patch("fetch_conditions.fetch_avalanche", return_value={"region": "north-cascades"}),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--coordinates",
+                    "48.77,-121.81",
+                    "--elevation",
+                    "3286",
+                    "--peak-name",
+                    "Mt Baker",
+                ],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "counties" in data
+        assert "nearest_hospital" in data
+        assert "ranger_station" in data
+        assert "campgrounds" in data
+        assert "gaps" in data
+
+    def test_trailhead_option_accepted(self):
+        """--trailhead option is accepted by cli()."""
+        from click.testing import CliRunner
+        from fetch_conditions import cli
+
+        runner = CliRunner()
+
+        with (
+            patch("fetch_conditions.fetch_counties", return_value={"counties": []}),
+            patch("fetch_conditions.fetch_nearest_hospital", return_value={"hospitals": []}),
+            patch("fetch_conditions.fetch_ranger_station", return_value={"stations": []}),
+            patch("fetch_conditions.fetch_campgrounds", return_value={"campgrounds": []}),
+            patch("fetch_conditions.fetch_weather", return_value={"forecast": []}),
+            patch("fetch_conditions.fetch_air_quality", return_value={"rating": "good"}),
+            patch("fetch_conditions.fetch_daylight", return_value={"sunrise": "6:00 AM"}),
+            patch("fetch_conditions.fetch_avalanche", return_value={"region": "north-cascades"}),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--coordinates",
+                    "48.77,-121.81",
+                    "--elevation",
+                    "3286",
+                    "--peak-name",
+                    "Mt Baker",
+                    "--trailhead",
+                    "48.60,-121.70",
+                ],
+            )
+
+        assert result.exit_code == 0
+
+    def test_fetcher_error_appended_to_gaps(self):
+        """When a fetcher returns an error, it is appended to gaps."""
+        from click.testing import CliRunner
+        from fetch_conditions import cli
+
+        runner = CliRunner()
+
+        with (
+            patch("fetch_conditions.fetch_counties", return_value={"error": "API down"}),
+            patch("fetch_conditions.fetch_nearest_hospital", return_value={"hospitals": []}),
+            patch("fetch_conditions.fetch_ranger_station", return_value={"stations": []}),
+            patch("fetch_conditions.fetch_campgrounds", return_value={"campgrounds": []}),
+            patch("fetch_conditions.fetch_weather", return_value={"forecast": []}),
+            patch("fetch_conditions.fetch_air_quality", return_value={"rating": "good"}),
+            patch("fetch_conditions.fetch_daylight", return_value={"sunrise": "6:00 AM"}),
+            patch("fetch_conditions.fetch_avalanche", return_value={"region": "north-cascades"}),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--coordinates",
+                    "48.77,-121.81",
+                    "--elevation",
+                    "3286",
+                    "--peak-name",
+                    "Mt Baker",
+                ],
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        gap_sources = [g.get("source", "") for g in data["gaps"]]
+        assert any("count" in s.lower() or "FCC" in s or "Counties" in s for s in gap_sources)

--- a/skills/route-researcher/tools/test_phase4.py
+++ b/skills/route-researcher/tools/test_phase4.py
@@ -1,0 +1,314 @@
+"""TDD tests for Phase 4 additions: twilight, snow-line, speed models.
+
+No mocks needed for fetch_daylight (uses astral library directly).
+estimate_times is pure Python — no mocking.
+CLI tests use CliRunner with patched fetchers.
+"""
+
+import json
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+from fetch_conditions import cli, estimate_times, fetch_daylight
+
+# ---------------------------------------------------------------------------
+# 1. Nautical + astronomical twilight in fetch_daylight
+# ---------------------------------------------------------------------------
+
+
+class TestFetchDaylightTwilight:
+    LAT, LON = 48.77, -121.81  # Mt Baker area
+    # Use winter date — at 48°N in December all twilight levels are well-defined.
+    # In summer (June), astronomical twilight may not occur (white nights).
+    DATE_WINTER = "2025-12-21"
+    DATE_SUMMER = "2025-06-21"
+
+    def test_nautical_dawn_key_present(self):
+        """nautical_dawn key is always present (may be None on white-night dates)."""
+        result = fetch_daylight(self.LAT, self.LON, self.DATE_WINTER)
+        assert "nautical_dawn" in result
+
+    def test_nautical_dusk_key_present(self):
+        result = fetch_daylight(self.LAT, self.LON, self.DATE_WINTER)
+        assert "nautical_dusk" in result
+
+    def test_astronomical_dawn_key_present(self):
+        result = fetch_daylight(self.LAT, self.LON, self.DATE_WINTER)
+        assert "astronomical_dawn" in result
+
+    def test_astronomical_dusk_key_present(self):
+        result = fetch_daylight(self.LAT, self.LON, self.DATE_WINTER)
+        assert "astronomical_dusk" in result
+
+    def test_twilight_order_astronomical_before_nautical_before_civil_before_sunrise(self):
+        """On winter date all twilights exist and are ordered correctly."""
+        result = fetch_daylight(self.LAT, self.LON, self.DATE_WINTER, "America/Los_Angeles")
+        assert "error" not in result
+        # All four should be non-None in winter at 48°N
+        assert result["astronomical_dawn"] is not None
+        assert result["nautical_dawn"] is not None
+
+        def parse_t(s):
+            return datetime.strptime(s, "%I:%M %p")
+
+        astro = parse_t(result["astronomical_dawn"])
+        naut = parse_t(result["nautical_dawn"])
+        civil = parse_t(result["civil_twilight"])
+        sunrise = parse_t(result["sunrise"])
+
+        assert astro < naut < civil < sunrise
+
+    def test_sunset_before_civil_dusk_before_nautical_dusk_before_astronomical_dusk(self):
+        """On winter date: sunset < civil_dusk < nautical_dusk < astronomical_dusk."""
+        result = fetch_daylight(self.LAT, self.LON, self.DATE_WINTER, "America/Los_Angeles")
+        assert "error" not in result
+        assert result["nautical_dusk"] is not None
+        assert result["astronomical_dusk"] is not None
+
+        def parse_t(s):
+            return datetime.strptime(s, "%I:%M %p")
+
+        sunset = parse_t(result["sunset"])
+        civil_dusk = parse_t(result["civil_dusk"])
+        naut_dusk = parse_t(result["nautical_dusk"])
+        astro_dusk = parse_t(result["astronomical_dusk"])
+
+        assert sunset < civil_dusk < naut_dusk < astro_dusk
+
+    def test_astronomical_dawn_none_on_white_night_date(self):
+        """At 48°N on summer solstice, astronomical twilight may not occur (None is valid)."""
+        result = fetch_daylight(self.LAT, self.LON, self.DATE_SUMMER)
+        assert "error" not in result
+        # Key must be present; value may be None
+        assert "astronomical_dawn" in result
+
+    def test_existing_keys_still_present(self):
+        """Existing keys (sunrise, sunset, civil_twilight, daylight_hours, timezone) survive."""
+        result = fetch_daylight(self.LAT, self.LON, self.DATE_WINTER)
+        for key in ("sunrise", "sunset", "civil_twilight", "daylight_hours", "timezone"):
+            assert key in result, f"Missing key: {key}"
+
+    def test_error_on_bad_date_still_returns_error_dict(self):
+        result = fetch_daylight(self.LAT, self.LON, "not-a-date")
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# 2. Freezing level / snow-line emphasis in fetch_weather output
+# ---------------------------------------------------------------------------
+
+
+class TestFreezingLevelSnowLine:
+    """fetch_weather already returns freezing_level_ft per day.
+    The new requirement adds snow_line_note and near_summit_flag per day.
+    These are derived in the weather output; we test via the cli() with mocked weather.
+    """
+
+    MOCK_FORECAST = [
+        {
+            "date": "2025-06-21",
+            "day": "Sat",
+            "conditions": "Clear",
+            "temp_high_f": 55,
+            "temp_low_f": 35,
+            "precip_prob": 10,
+            "wind_max_mph": 15,
+            "freezing_level_ft": 8000,  # well above summit (summit ~10,000 ft)
+        },
+        {
+            "date": "2025-06-22",
+            "day": "Sun",
+            "conditions": "Clear",
+            "temp_high_f": 50,
+            "temp_low_f": 30,
+            "precip_prob": 5,
+            "wind_max_mph": 10,
+            "freezing_level_ft": 9500,  # within 2000 ft of summit at 10,000 ft (500 ft gap)
+        },
+    ]
+
+    def _run_cli_with_mock_weather(self, forecast, elevation_m=3048.0):
+        """elevation_m=3048 ≈ 10,000 ft."""
+        runner = CliRunner()
+        mock_weather = {"forecast": forecast, "timezone": "America/Los_Angeles"}
+
+        with (
+            patch("fetch_conditions.fetch_weather", return_value=mock_weather),
+            patch("fetch_conditions.fetch_air_quality", return_value={"rating": "good"}),
+            patch("fetch_conditions.fetch_daylight", return_value={"sunrise": "5:00 AM"}),
+            patch("fetch_conditions.fetch_avalanche", return_value={"region": "north-cascades"}),
+            patch("fetch_conditions.fetch_counties", return_value={"counties": []}),
+            patch("fetch_conditions.fetch_nearest_hospital", return_value={"hospitals": []}),
+            patch("fetch_conditions.fetch_ranger_station", return_value={"stations": []}),
+            patch("fetch_conditions.fetch_campgrounds", return_value={"campgrounds": []}),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "--coordinates",
+                    "48.77,-121.81",
+                    "--elevation",
+                    str(elevation_m),
+                    "--peak-name",
+                    "Test Peak",
+                ],
+            )
+        return result
+
+    def test_snow_line_note_present_per_day(self):
+        """Each forecast day has a snow_line_note string."""
+        result = self._run_cli_with_mock_weather(self.MOCK_FORECAST)
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        for day in data["weather"]["forecast"]:
+            assert "snow_line_note" in day, f"Missing snow_line_note in {day}"
+
+    def test_near_summit_flag_false_when_freezing_level_well_above(self):
+        """near_summit=False when freezing level is > 2000 ft above summit."""
+        # Summit at 10,000 ft, freezing at 8000 ft — freezing is BELOW summit by 2000 ft
+        # "within 2000 ft of summit" means abs(summit_ft - freezing_ft) <= 2000
+        result = self._run_cli_with_mock_weather(self.MOCK_FORECAST[:1], elevation_m=3048.0)
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        day = data["weather"]["forecast"][0]
+        assert "near_summit" in day
+        # freezing=8000 ft, summit=10,000 ft, diff=2000 ft — on the boundary; test the flag logic
+        # just assert the key exists and is bool
+        assert isinstance(day["near_summit"], bool)
+
+    def test_near_summit_flag_true_when_freezing_level_within_2000ft(self):
+        """near_summit=True when freezing level is within 2000 ft of summit."""
+        # freezing_level_ft=9500, summit≈10,000 ft (3048m), diff=500 ft → within 2000 ft
+        result = self._run_cli_with_mock_weather(self.MOCK_FORECAST[1:], elevation_m=3048.0)
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        day = data["weather"]["forecast"][0]
+        assert day["near_summit"] is True
+
+    def test_snow_line_note_mentions_elevation(self):
+        """snow_line_note contains a numeric elevation reference."""
+        result = self._run_cli_with_mock_weather(self.MOCK_FORECAST[:1])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        note = data["weather"]["forecast"][0]["snow_line_note"]
+        # Should contain a number (the freezing level elevation)
+        assert any(ch.isdigit() for ch in note)
+
+    def test_missing_freezing_level_handled_gracefully(self):
+        """Day with freezing_level_ft=None doesn't crash."""
+        forecast = [{**self.MOCK_FORECAST[0], "freezing_level_ft": None}]
+        result = self._run_cli_with_mock_weather(forecast)
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        day = data["weather"]["forecast"][0]
+        assert "snow_line_note" in day
+
+
+# ---------------------------------------------------------------------------
+# 3. estimate_times pure helper
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateTimes:
+    def test_returns_dict_with_roped_and_unroped_keys(self):
+        result = estimate_times(5.0, 3000)
+        assert "roped_hr" in result
+        assert "unroped_hr" in result
+
+    def test_roped_uses_1_mph_pace(self):
+        """Roped time = distance_mi / 1.0 mi/hr."""
+        result = estimate_times(4.0, 1000)
+        assert result["roped_hr"] == pytest.approx(4.0)
+
+    def test_unroped_uses_1000_ft_per_hr_gain(self):
+        """Unroped time = gain_ft / 1000 ft/hr."""
+        result = estimate_times(2.0, 2000)
+        assert result["unroped_hr"] == pytest.approx(2.0)
+
+    def test_roped_uses_slower_of_distance_and_gain(self):
+        """Roped = max(distance/1.0, gain/1000) to account for whichever is limiting."""
+        # distance=2 mi → 2 hr; gain=4000 ft → 4 hr: roped should be 4 hr
+        result = estimate_times(2.0, 4000)
+        assert result["roped_hr"] == pytest.approx(4.0)
+
+    def test_existing_pacing_tiers_still_present(self):
+        """fast, moderate, leisurely keys still returned."""
+        result = estimate_times(5.0, 3000)
+        for key in ("fast_hr", "moderate_hr", "leisurely_hr"):
+            assert key in result, f"Missing pacing key: {key}"
+
+    def test_zero_gain_handled(self):
+        """Zero gain doesn't divide by zero or crash."""
+        result = estimate_times(3.0, 0)
+        assert "roped_hr" in result
+        assert "unroped_hr" in result
+
+    def test_zero_distance_handled(self):
+        result = estimate_times(0.0, 1000)
+        assert "roped_hr" in result
+
+
+# ---------------------------------------------------------------------------
+# 4. CLI wiring — time_estimates key
+# ---------------------------------------------------------------------------
+
+
+class TestCliTimeEstimates:
+    def _run_cli(self, extra_args=None):
+        runner = CliRunner()
+        base_args = [
+            "--coordinates",
+            "48.77,-121.81",
+            "--elevation",
+            "3286",
+            "--peak-name",
+            "Mt Baker",
+        ]
+        with (
+            patch(
+                "fetch_conditions.fetch_weather", return_value={"forecast": [], "timezone": None}
+            ),
+            patch("fetch_conditions.fetch_air_quality", return_value={"rating": "good"}),
+            patch("fetch_conditions.fetch_daylight", return_value={"sunrise": "5:00 AM"}),
+            patch("fetch_conditions.fetch_avalanche", return_value={"region": "north-cascades"}),
+            patch("fetch_conditions.fetch_counties", return_value={"counties": []}),
+            patch("fetch_conditions.fetch_nearest_hospital", return_value={"hospitals": []}),
+            patch("fetch_conditions.fetch_ranger_station", return_value={"stations": []}),
+            patch("fetch_conditions.fetch_campgrounds", return_value={"campgrounds": []}),
+        ):
+            return runner.invoke(cli, base_args + (extra_args or []))
+
+    def test_time_estimates_absent_when_args_not_provided(self):
+        result = self._run_cli()
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "time_estimates" not in data
+
+    def test_time_estimates_present_when_both_args_provided(self):
+        result = self._run_cli(["--distance-mi", "6.0", "--gain-ft", "4500"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "time_estimates" in data
+
+    def test_time_estimates_contains_roped_and_unroped(self):
+        result = self._run_cli(["--distance-mi", "6.0", "--gain-ft", "4500"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        te = data["time_estimates"]
+        assert "roped_hr" in te
+        assert "unroped_hr" in te
+
+    def test_time_estimates_absent_when_only_distance_provided(self):
+        """Both args required — only distance should not emit the key."""
+        result = self._run_cli(["--distance-mi", "6.0"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "time_estimates" not in data
+
+    def test_time_estimates_absent_when_only_gain_provided(self):
+        result = self._run_cli(["--gain-ft", "4500"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "time_estimates" not in data

--- a/skills/route-researcher/tools/test_phase4.py
+++ b/skills/route-researcher/tools/test_phase4.py
@@ -165,18 +165,23 @@ class TestFreezingLevelSnowLine:
         for day in data["weather"]["forecast"]:
             assert "snow_line_note" in day, f"Missing snow_line_note in {day}"
 
-    def test_near_summit_flag_false_when_freezing_level_well_above(self):
-        """near_summit=False when freezing level is > 2000 ft above summit."""
-        # Summit at 10,000 ft, freezing at 8000 ft — freezing is BELOW summit by 2000 ft
-        # "within 2000 ft of summit" means abs(summit_ft - freezing_ft) <= 2000
+    def test_near_summit_flag_false_when_diff_exceeds_2000ft(self):
+        """near_summit=False when abs(summit_ft - freezing_ft) > 2000."""
+        # freezing=8000 ft, summit=3353m≈11,000 ft → diff=3000 ft > 2000 → False
+        result = self._run_cli_with_mock_weather(self.MOCK_FORECAST[:1], elevation_m=3353.0)
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        day = data["weather"]["forecast"][0]
+        assert day["near_summit"] is False
+
+    def test_near_summit_flag_true_when_diff_exactly_2000ft(self):
+        """near_summit=True when abs(summit_ft - freezing_ft) == 2000 (boundary is inclusive)."""
+        # freezing=8000 ft, summit=3048m≈10,000 ft → diff=2000 ft → within → True
         result = self._run_cli_with_mock_weather(self.MOCK_FORECAST[:1], elevation_m=3048.0)
         assert result.exit_code == 0
         data = json.loads(result.output)
         day = data["weather"]["forecast"][0]
-        assert "near_summit" in day
-        # freezing=8000 ft, summit=10,000 ft, diff=2000 ft — on the boundary; test the flag logic
-        # just assert the key exists and is bool
-        assert isinstance(day["near_summit"], bool)
+        assert day["near_summit"] is True
 
     def test_near_summit_flag_true_when_freezing_level_within_2000ft(self):
         """near_summit=True when freezing level is within 2000 ft of summit."""

--- a/skills/route-researcher/tools/test_phase5.py
+++ b/skills/route-researcher/tools/test_phase5.py
@@ -233,6 +233,45 @@ class TestBuildItinerary:
         assert "total_hr" in result
         assert result["total_hr"] > 0
 
+    # --- cross-midnight day-marker tests (Wave F P1 re-open) ---
+
+    def test_cross_midnight_summit_eta_has_plus1d_marker(self):
+        """Evening start (18:00) with long route: summit_eta wraps to next day.
+
+        summit_eta '07:18' is ambiguous — looks like 7am same day, before the
+        18:00 start.  Must be '07:18 (+1d)' to be unambiguous.
+        """
+        result = build_itinerary("18:00", 20.0, 8000, self.DAYLIGHT)
+        assert "(+1d)" in result["summit_eta"], (
+            f"summit_eta {result['summit_eta']!r} should contain '(+1d)' for cross-midnight route"
+        )
+
+    def test_cross_midnight_return_eta_has_plus1d_marker(self):
+        """Evening start with long route: return_eta wraps to next day, must say (+1d)."""
+        result = build_itinerary("18:00", 20.0, 8000, self.DAYLIGHT)
+        assert "(+1d)" in result["return_eta"], (
+            f"return_eta {result['return_eta']!r} should contain '(+1d)' for cross-midnight route"
+        )
+
+    def test_cross_midnight_after_dark_true(self):
+        """Evening start with 20mi/8000ft route: return is well past dusk → after_dark=True."""
+        result = build_itinerary("18:00", 20.0, 8000, self.DAYLIGHT)
+        assert result["after_dark"] is True
+
+    def test_normal_daytime_route_has_no_plus1d_marker(self):
+        """A standard daytime route that finishes same day must NOT have (+1d) markers."""
+        result = build_itinerary("06:00", 8.0, 4000, self.DAYLIGHT)
+        assert "(+1d)" not in result["summit_eta"]
+        assert "(+1d)" not in result["return_eta"]
+
+    def test_turnaround_same_day_no_plus1d_when_evening_start(self):
+        """For evening start, turnaround_by (dusk - descent_hr) stays same day — no (+1d)."""
+        # 18:00 start, dusk 22:00: turnaround = 22:00 - descent, same evening
+        result = build_itinerary("18:00", 20.0, 8000, self.DAYLIGHT)
+        assert "(+1d)" not in result["turnaround_by"], (
+            f"turnaround_by {result['turnaround_by']!r} should be same-day for evening start"
+        )
+
 
 # ---------------------------------------------------------------------------
 # 2. compute_bearings helper

--- a/skills/route-researcher/tools/test_phase5.py
+++ b/skills/route-researcher/tools/test_phase5.py
@@ -1,0 +1,374 @@
+"""TDD tests for Phase 5 additions: itinerary generator + navigation bearings.
+
+Pure-Python helpers — no HTTP mocks needed.
+CLI tests use CliRunner with all fetchers patched.
+"""
+
+import json
+from unittest.mock import patch
+
+from click.testing import CliRunner
+from fetch_conditions import build_itinerary, cli, compute_bearings
+
+# ---------------------------------------------------------------------------
+# Helpers shared across tests
+# ---------------------------------------------------------------------------
+
+_PATCH_ALL_FETCHERS = (
+    patch("fetch_conditions.fetch_weather", return_value={"forecast": [], "timezone": None}),
+    patch("fetch_conditions.fetch_air_quality", return_value={"rating": "good"}),
+    patch(
+        "fetch_conditions.fetch_daylight",
+        return_value={"sunrise": "5:00 AM", "sunset": "9:00 PM", "nautical_dusk": "10:30 PM"},
+    ),
+    patch("fetch_conditions.fetch_avalanche", return_value={"region": "north-cascades"}),
+    patch("fetch_conditions.fetch_counties", return_value={"counties": []}),
+    patch("fetch_conditions.fetch_nearest_hospital", return_value={"hospitals": []}),
+    patch("fetch_conditions.fetch_ranger_station", return_value={"stations": []}),
+    patch("fetch_conditions.fetch_campgrounds", return_value={"campgrounds": []}),
+)
+
+BASE_CLI_ARGS = [
+    "--coordinates",
+    "48.77,-121.81",
+    "--elevation",
+    "3286",
+    "--peak-name",
+    "Mt Baker",
+]
+
+
+def _run_cli(extra_args=None):
+    runner = CliRunner()
+    with (
+        patch("fetch_conditions.fetch_weather", return_value={"forecast": [], "timezone": None}),
+        patch("fetch_conditions.fetch_air_quality", return_value={"rating": "good"}),
+        patch(
+            "fetch_conditions.fetch_daylight",
+            return_value={
+                "sunrise": "5:00 AM",
+                "sunset": "9:00 PM",
+                "civil_dusk": "9:30 PM",
+                "nautical_dusk": "10:00 PM",
+            },
+        ),
+        patch("fetch_conditions.fetch_avalanche", return_value={"region": "north-cascades"}),
+        patch("fetch_conditions.fetch_counties", return_value={"counties": []}),
+        patch("fetch_conditions.fetch_nearest_hospital", return_value={"hospitals": []}),
+        patch("fetch_conditions.fetch_ranger_station", return_value={"stations": []}),
+        patch("fetch_conditions.fetch_campgrounds", return_value={"campgrounds": []}),
+    ):
+        return runner.invoke(cli, BASE_CLI_ARGS + (extra_args or []))
+
+
+# ---------------------------------------------------------------------------
+# 1. build_itinerary helper
+# ---------------------------------------------------------------------------
+
+
+class TestBuildItinerary:
+    """build_itinerary(start_time, distance_mi, gain_ft, daylight) -> dict"""
+
+    DAYLIGHT = {
+        "sunrise": "5:00 AM",
+        "sunset": "9:00 PM",
+        "civil_dusk": "9:30 PM",
+        "nautical_dusk": "10:00 PM",
+    }
+
+    def test_returns_start_time(self):
+        result = build_itinerary("06:00", 8.0, 4000, self.DAYLIGHT)
+        assert "start_time" in result
+        assert result["start_time"] == "06:00"
+
+    def test_returns_summit_eta(self):
+        """summit_eta is present and a time string."""
+        result = build_itinerary("06:00", 8.0, 4000, self.DAYLIGHT)
+        assert "summit_eta" in result
+        assert isinstance(result["summit_eta"], str)
+
+    def test_returns_turnaround_time(self):
+        result = build_itinerary("06:00", 8.0, 4000, self.DAYLIGHT)
+        assert "turnaround_by" in result
+
+    def test_returns_return_eta(self):
+        result = build_itinerary("06:00", 8.0, 4000, self.DAYLIGHT)
+        assert "return_eta" in result
+
+    def test_summit_eta_later_than_start(self):
+        """Summit ETA must be after start time."""
+        result = build_itinerary("06:00", 8.0, 4000, self.DAYLIGHT)
+        from datetime import datetime
+
+        start = datetime.strptime("06:00", "%H:%M")
+        summit = datetime.strptime(result["summit_eta"], "%H:%M")
+        assert summit > start
+
+    def test_return_eta_later_than_summit(self):
+        """Return ETA must be after summit ETA."""
+        result = build_itinerary("06:00", 8.0, 4000, self.DAYLIGHT)
+        from datetime import datetime
+
+        summit = datetime.strptime(result["summit_eta"], "%H:%M")
+        ret = datetime.strptime(result["return_eta"], "%H:%M")
+        assert ret > summit
+
+    def test_after_dark_warning_false_when_return_before_nautical_dusk(self):
+        """after_dark=False when return ETA is before nautical dusk."""
+        # Start early, short route — should finish well before dark
+        result = build_itinerary("05:00", 4.0, 2000, self.DAYLIGHT)
+        assert "after_dark" in result
+        assert result["after_dark"] is False
+
+    def test_after_dark_warning_true_when_return_after_nautical_dusk(self):
+        """after_dark=True when projected return is after nautical dusk."""
+        # Start late with a long route — will finish after dark
+        result = build_itinerary("14:00", 12.0, 6000, self.DAYLIGHT)
+        assert "after_dark" in result
+        assert result["after_dark"] is True
+
+    def test_turnaround_based_on_dusk_cutoff(self):
+        """turnaround_by is derived from the dusk cutoff, not an arbitrary value."""
+        result = build_itinerary("06:00", 8.0, 4000, self.DAYLIGHT)
+        # turnaround_by should be before nautical_dusk (10:00 PM)
+        from datetime import datetime
+
+        turnaround = datetime.strptime(result["turnaround_by"], "%H:%M")
+        naut_dusk = datetime.strptime("22:00", "%H:%M")
+        assert turnaround <= naut_dusk
+
+    def test_missing_daylight_keys_handled_gracefully(self):
+        """Sparse daylight dict (missing dusk keys) doesn't crash."""
+        sparse = {"sunrise": "5:00 AM", "sunset": "9:00 PM"}
+        result = build_itinerary("06:00", 8.0, 4000, sparse)
+        assert "summit_eta" in result
+        # after_dark may be None or False when dusk unknown
+        assert "after_dark" in result
+
+    # --- date-anchoring and turnaround semantics (P1 fixes) ---
+
+    def test_pre_dawn_start_summit_eta_uses_elapsed_hours(self):
+        """Pre-dawn start (02:00), long route: total_hr captures full elapsed time.
+
+        If result times are re-parsed as HH:MM on 1900-01-01, a summit at 14:00
+        looks correct, but a summit at 02:30+12hr=14:30 is fine; the real anchor
+        test is total_hr which must equal ascent+descent regardless of wall-clock wrapping.
+        """
+        result = build_itinerary("02:00", 10.0, 5000, self.DAYLIGHT)
+        assert "total_hr" in result
+        assert result["total_hr"] > 0
+
+    def test_after_midnight_finish_after_dark_true(self):
+        """A route finishing after midnight must report after_dark=True.
+
+        Re-parsing '00:30' as datetime gives 1900-01-01 00:30 which is LESS
+        than dusk 1900-01-01 22:00, so the naive comparison reports after_dark=False.
+        The fix uses elapsed timedeltas from start so midnight wrapping is handled.
+        """
+        # Start 21:00, short enough route that naive strptime wraps: ascent ~5hr → summit 02:00,
+        # descent ~2.5hr → return 04:30 — all past dusk (22:00) but naive comparison says False.
+        result = build_itinerary("21:00", 8.0, 5000, self.DAYLIGHT)
+        # return_eta wraps past midnight; after_dark must still be True
+        assert result["after_dark"] is True
+
+    def test_turnaround_before_summit_when_day_too_short(self):
+        """When dusk - descent_time < summit_eta, turnaround_by comes before summit in elapsed time.
+
+        Start 18:00, nautical dusk 22:00.  Moderate ascent for 10mi/5000ft
+        takes ~7hr → summit at 01:18 next day (past dusk).  Latest safe
+        turnaround = dusk(22:00) - descent_hr ≈ 19:18, which is only 1.3hr
+        after start — far less than the 7.3hr to summit.
+
+        Wall-clock strings can't be compared directly when summit wraps past midnight,
+        so use elapsed_hr_to_turnaround < ascent_hr as the assertion.
+        """
+        late_start = {
+            "sunrise": "5:00 AM",
+            "sunset": "9:00 PM",
+            "civil_dusk": "9:30 PM",
+            "nautical_dusk": "10:00 PM",
+        }
+        result = build_itinerary("18:00", 10.0, 5000, late_start)
+        # after_dark must be True (summit and return are past dusk)
+        assert result["after_dark"] is True
+        # Elapsed time to turnaround < elapsed time to summit.
+        # Compute both as minutes-from-start using total_hr as anchor.
+        # turnaround_by = dusk - descent_hr = 22:00 - ~2.7hr = ~19:18 → 1hr18min from 18:00 start
+        # summit_eta = 18:00 + 7.3hr = 01:18 next day → 7hr18min from start
+        from datetime import datetime
+
+        start = datetime.strptime("18:00", "%H:%M")
+        turnaround = datetime.strptime(result["turnaround_by"], "%H:%M")
+        # elapsed to turnaround (turnaround is same day as start for this case)
+        turnaround_elapsed = (turnaround - start).total_seconds()
+        if turnaround_elapsed < 0:
+            turnaround_elapsed += 86400  # wrap: turnaround next day
+        # turnaround elapsed must be less than total route time
+        assert turnaround_elapsed < result["total_hr"] * 3600
+
+    def test_turnaround_equals_dusk_minus_descent_when_summitable(self):
+        """turnaround_by = dusk - descent_hr when summit is reachable before dusk.
+
+        Definition: the latest time you can start descending and still return
+        before nautical dusk.  For a 06:00 start / 8mi / 4000ft route:
+          moderate ascent ≈ 4hr → summit 10:00
+          fast descent ≈ 0.5 * fast_hr
+          dusk = 22:00
+          turnaround = 22:00 - descent_hr (should be before dusk, after summit)
+        """
+        result = build_itinerary("06:00", 8.0, 4000, self.DAYLIGHT)
+        from datetime import datetime
+
+        summit = datetime.strptime(result["summit_eta"], "%H:%M")
+        turnaround = datetime.strptime(result["turnaround_by"], "%H:%M")
+        naut_dusk = datetime.strptime("22:00", "%H:%M")
+        # turnaround must be after summit (you still reach the top)
+        assert turnaround >= summit
+        # and before or at dusk
+        assert turnaround <= naut_dusk
+
+    def test_elapsed_hours_output_key_present(self):
+        """Result exposes elapsed_hours for programmatic use."""
+        result = build_itinerary("06:00", 8.0, 4000, self.DAYLIGHT)
+        assert "total_hr" in result
+        assert result["total_hr"] > 0
+
+
+# ---------------------------------------------------------------------------
+# 2. compute_bearings helper
+# ---------------------------------------------------------------------------
+
+
+class TestComputeBearings:
+    """compute_bearings(waypoints) -> dict"""
+
+    def test_returns_segments_list(self):
+        waypoints = [(47.0, -121.0), (48.0, -121.0)]
+        result = compute_bearings(waypoints)
+        assert "segments" in result
+        assert isinstance(result["segments"], list)
+        assert len(result["segments"]) == 1
+
+    def test_due_north_bearing_is_zero(self):
+        """Moving due north: bearing ≈ 0° (or 360°)."""
+        waypoints = [(47.0, -121.0), (48.0, -121.0)]
+        result = compute_bearings(waypoints)
+        bearing = result["segments"][0]["bearing_deg"]
+        # Due north is 0° or 360°
+        assert bearing < 5 or bearing > 355
+
+    def test_due_east_bearing_is_90(self):
+        """Moving due east: bearing ≈ 90°."""
+        waypoints = [(47.0, -122.0), (47.0, -121.0)]
+        result = compute_bearings(waypoints)
+        bearing = result["segments"][0]["bearing_deg"]
+        assert abs(bearing - 90) < 5
+
+    def test_due_south_bearing_is_180(self):
+        """Moving due south: bearing ≈ 180°."""
+        waypoints = [(48.0, -121.0), (47.0, -121.0)]
+        result = compute_bearings(waypoints)
+        bearing = result["segments"][0]["bearing_deg"]
+        assert abs(bearing - 180) < 5
+
+    def test_segment_includes_distance_miles(self):
+        waypoints = [(47.0, -121.0), (48.0, -121.0)]
+        result = compute_bearings(waypoints)
+        seg = result["segments"][0]
+        assert "distance_mi" in seg
+        assert seg["distance_mi"] > 0
+
+    def test_cumulative_distance_in_segments(self):
+        """Each segment has cumulative_distance_mi."""
+        waypoints = [(47.0, -121.0), (48.0, -121.0), (49.0, -121.0)]
+        result = compute_bearings(waypoints)
+        assert (
+            result["segments"][0]["cumulative_distance_mi"]
+            < result["segments"][1]["cumulative_distance_mi"]
+        )
+
+    def test_multi_segment_count(self):
+        """N waypoints produces N-1 segments."""
+        waypoints = [(47.0, -121.0), (47.5, -121.0), (48.0, -121.0), (48.5, -121.5)]
+        result = compute_bearings(waypoints)
+        assert len(result["segments"]) == 3
+
+    def test_total_distance_present(self):
+        waypoints = [(47.0, -121.0), (48.0, -121.0), (49.0, -121.0)]
+        result = compute_bearings(waypoints)
+        assert "total_distance_mi" in result
+        assert result["total_distance_mi"] > 0
+
+    def test_single_waypoint_returns_empty_segments(self):
+        """Single point → no segments, no error."""
+        result = compute_bearings([(47.0, -121.0)])
+        assert "segments" in result
+        assert result["segments"] == []
+
+    def test_empty_waypoints_returns_empty_segments(self):
+        result = compute_bearings([])
+        assert "segments" in result
+        assert result["segments"] == []
+
+    def test_segment_includes_from_to_labels(self):
+        """Each segment has from/to indices or coords for readability."""
+        waypoints = [(47.0, -121.0), (48.0, -121.0)]
+        result = compute_bearings(waypoints)
+        seg = result["segments"][0]
+        assert "from" in seg or "waypoint_index" in seg
+
+
+# ---------------------------------------------------------------------------
+# 3. CLI wiring
+# ---------------------------------------------------------------------------
+
+
+class TestCliItinerary:
+    def test_itinerary_absent_when_start_time_not_provided(self):
+        result = _run_cli(["--distance-mi", "8.0", "--gain-ft", "4000"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "itinerary" not in data
+
+    def test_itinerary_absent_when_distance_not_provided(self):
+        result = _run_cli(["--start-time", "06:00", "--gain-ft", "4000"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "itinerary" not in data
+
+    def test_itinerary_present_when_all_args_provided(self):
+        result = _run_cli(["--start-time", "06:00", "--distance-mi", "8.0", "--gain-ft", "4000"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "itinerary" in data
+
+    def test_itinerary_contains_required_keys(self):
+        result = _run_cli(["--start-time", "06:00", "--distance-mi", "8.0", "--gain-ft", "4000"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        it = data["itinerary"]
+        assert "start_time" in it
+        assert "summit_eta" in it
+        assert "return_eta" in it
+        assert "after_dark" in it
+
+
+class TestCliBearings:
+    def test_bearings_absent_when_no_waypoints(self):
+        result = _run_cli()
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "bearings" not in data
+
+    def test_bearings_present_when_waypoints_provided(self):
+        result = _run_cli(["--waypoint", "47.0,-121.0", "--waypoint", "48.0,-121.0"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "bearings" in data
+
+    def test_bearings_contains_segments(self):
+        result = _run_cli(["--waypoint", "47.0,-121.0", "--waypoint", "48.0,-121.0"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert "segments" in data["bearings"]
+        assert len(data["bearings"]["segments"]) == 1

--- a/skills/route-researcher/tools/test_phase5.py
+++ b/skills/route-researcher/tools/test_phase5.py
@@ -14,20 +14,6 @@ from fetch_conditions import build_itinerary, cli, compute_bearings
 # Helpers shared across tests
 # ---------------------------------------------------------------------------
 
-_PATCH_ALL_FETCHERS = (
-    patch("fetch_conditions.fetch_weather", return_value={"forecast": [], "timezone": None}),
-    patch("fetch_conditions.fetch_air_quality", return_value={"rating": "good"}),
-    patch(
-        "fetch_conditions.fetch_daylight",
-        return_value={"sunrise": "5:00 AM", "sunset": "9:00 PM", "nautical_dusk": "10:30 PM"},
-    ),
-    patch("fetch_conditions.fetch_avalanche", return_value={"region": "north-cascades"}),
-    patch("fetch_conditions.fetch_counties", return_value={"counties": []}),
-    patch("fetch_conditions.fetch_nearest_hospital", return_value={"hospitals": []}),
-    patch("fetch_conditions.fetch_ranger_station", return_value={"stations": []}),
-    patch("fetch_conditions.fetch_campgrounds", return_value={"campgrounds": []}),
-)
-
 BASE_CLI_ARGS = [
     "--coordinates",
     "48.77,-121.81",
@@ -272,6 +258,31 @@ class TestBuildItinerary:
             f"turnaround_by {result['turnaround_by']!r} should be same-day for evening start"
         )
 
+    def test_degenerate_zero_distance_zero_gain(self):
+        """distance_mi=0, gain_ft=0: summit==return==start, total_hr==0, no crash."""
+        result = build_itinerary("06:00", 0.0, 0.0, self.DAYLIGHT)
+        assert "start_time" in result
+        assert result["total_hr"] == 0.0
+        assert result["summit_eta"] == "06:00"
+        assert result["return_eta"] == "06:00"
+
+    def test_descent_hr_uses_raw_fast_formula(self):
+        """descent_hr = (dist/3.5 + gain/2000) * 0.5, not times['fast_hr'] * 0.5.
+
+        Using the pre-rounded fast_hr introduces ±3 min rounding error.
+        The raw formula must give a more precise result for non-trivial routes.
+        """
+        from fetch_conditions import estimate_times
+
+        dist, gain = 8.0, 4000
+        times = estimate_times(dist, gain)
+        raw_descent = (dist / 3.5 + gain / 2000) * 0.5
+        # Build the itinerary and verify total_hr uses the raw (unrounded) descent value
+        result = build_itinerary("06:00", dist, gain, self.DAYLIGHT)
+        ascent_hr = times["moderate_hr"]
+        expected_total = round(ascent_hr + raw_descent, 1)
+        assert result["total_hr"] == expected_total
+
 
 # ---------------------------------------------------------------------------
 # 2. compute_bearings helper
@@ -354,7 +365,7 @@ class TestComputeBearings:
         waypoints = [(47.0, -121.0), (48.0, -121.0)]
         result = compute_bearings(waypoints)
         seg = result["segments"][0]
-        assert "from" in seg or "waypoint_index" in seg
+        assert "from" in seg
 
 
 # ---------------------------------------------------------------------------

--- a/skills/route-researcher/tools/uv.lock
+++ b/skills/route-researcher/tools/uv.lock
@@ -2,27 +2,21 @@ version = 1
 revision = 3
 requires-python = ">=3.11"
 
-[[package]]
-name = "annotated-types"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
-]
+[options]
+exclude-newer = "2026-05-15T08:53:55.090921Z"
+exclude-newer-span = "P7D"
 
 [[package]]
 name = "anyio"
-version = "4.11.0"
+version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
-    { name = "sniffio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/78/7d432127c41b50bccba979505f272c16cbcadcc33645d5fa3a738110ae75/anyio-4.11.0.tar.gz", hash = "sha256:82a8d0b81e318cc5ce71a5f1f8b5c4e63619620b63141ef8c995fa0db95a57c4", size = 219094, upload-time = "2025-09-23T09:19:12.58Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/b3/9b1a8074496371342ec1e796a96f99c82c945a339cd81a8e73de28b4cf9e/anyio-4.11.0-py3-none-any.whl", hash = "sha256:0287e96f4d26d4149305414d4e3bc32f0dcd0862365a4bddea19d7a1ec38c4fc", size = 109097, upload-time = "2025-09-23T09:19:10.601Z" },
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
 ]
 
 [[package]]
@@ -38,124 +32,24 @@ wheels = [
 ]
 
 [[package]]
-name = "beautifulsoup4"
-version = "4.14.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "soupsieve" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/77/e9/df2358efd7659577435e2177bfa69cba6c33216681af51a707193dec162a/beautifulsoup4-4.14.2.tar.gz", hash = "sha256:2a98ab9f944a11acee9cc848508ec28d9228abfd522ef0fad6a02a72e0ded69e", size = 625822, upload-time = "2025-09-29T10:05:42.613Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/fe/3aed5d0be4d404d12d36ab97e2f1791424d9ca39c2f754a6285d59a3b01d/beautifulsoup4-4.14.2-py3-none-any.whl", hash = "sha256:5ef6fa3a8cbece8488d66985560f97ed091e22bbc4e9c2338508a9d5de6d4515", size = 106392, upload-time = "2025-09-29T10:05:43.771Z" },
-]
-
-[[package]]
 name = "certifi"
-version = "2025.10.5"
+version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4c/5b/b6ce21586237c77ce67d01dc5507039d444b630dd76611bbca2d8e5dcd91/certifi-2025.10.5.tar.gz", hash = "sha256:47c09d31ccf2acf0be3f701ea53595ee7e0b8fa08801c6624be771df09ae7b43", size = 164519, upload-time = "2025-10-05T04:12:15.808Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/37/af0d2ef3967ac0d6113837b44a4f0bfe1328c2b9763bd5b1744520e5cfed/certifi-2025.10.5-py3-none-any.whl", hash = "sha256:0f212c2744a9bb6de0c56639a6f68afe01ecd92d91f14ae897c4fe7bbeeef0de", size = 163286, upload-time = "2025-10-05T04:12:14.03Z" },
-]
-
-[[package]]
-name = "charset-normalizer"
-version = "3.4.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz", hash = "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a", size = 129418, upload-time = "2025-10-14T04:42:32.879Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/27/c6491ff4954e58a10f69ad90aca8a1b6fe9c5d3c6f380907af3c37435b59/charset_normalizer-3.4.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6e1fcf0720908f200cd21aa4e6750a48ff6ce4afe7ff5a79a90d5ed8a08296f8", size = 206988, upload-time = "2025-10-14T04:40:33.79Z" },
-    { url = "https://files.pythonhosted.org/packages/94/59/2e87300fe67ab820b5428580a53cad894272dbb97f38a7a814a2a1ac1011/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f819d5fe9234f9f82d75bdfa9aef3a3d72c4d24a6e57aeaebba32a704553aa0", size = 147324, upload-time = "2025-10-14T04:40:34.961Z" },
-    { url = "https://files.pythonhosted.org/packages/07/fb/0cf61dc84b2b088391830f6274cb57c82e4da8bbc2efeac8c025edb88772/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a59cb51917aa591b1c4e6a43c132f0cdc3c76dbad6155df4e28ee626cc77a0a3", size = 142742, upload-time = "2025-10-14T04:40:36.105Z" },
-    { url = "https://files.pythonhosted.org/packages/62/8b/171935adf2312cd745d290ed93cf16cf0dfe320863ab7cbeeae1dcd6535f/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8ef3c867360f88ac904fd3f5e1f902f13307af9052646963ee08ff4f131adafc", size = 160863, upload-time = "2025-10-14T04:40:37.188Z" },
-    { url = "https://files.pythonhosted.org/packages/09/73/ad875b192bda14f2173bfc1bc9a55e009808484a4b256748d931b6948442/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d9e45d7faa48ee908174d8fe84854479ef838fc6a705c9315372eacbc2f02897", size = 157837, upload-time = "2025-10-14T04:40:38.435Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/fc/de9cce525b2c5b94b47c70a4b4fb19f871b24995c728e957ee68ab1671ea/charset_normalizer-3.4.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:840c25fb618a231545cbab0564a799f101b63b9901f2569faecd6b222ac72381", size = 151550, upload-time = "2025-10-14T04:40:40.053Z" },
-    { url = "https://files.pythonhosted.org/packages/55/c2/43edd615fdfba8c6f2dfbd459b25a6b3b551f24ea21981e23fb768503ce1/charset_normalizer-3.4.4-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ca5862d5b3928c4940729dacc329aa9102900382fea192fc5e52eb69d6093815", size = 149162, upload-time = "2025-10-14T04:40:41.163Z" },
-    { url = "https://files.pythonhosted.org/packages/03/86/bde4ad8b4d0e9429a4e82c1e8f5c659993a9a863ad62c7df05cf7b678d75/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9c7f57c3d666a53421049053eaacdd14bbd0a528e2186fcb2e672effd053bb0", size = 150019, upload-time = "2025-10-14T04:40:42.276Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/86/a151eb2af293a7e7bac3a739b81072585ce36ccfb4493039f49f1d3cae8c/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:277e970e750505ed74c832b4bf75dac7476262ee2a013f5574dd49075879e161", size = 143310, upload-time = "2025-10-14T04:40:43.439Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/fe/43dae6144a7e07b87478fdfc4dbe9efd5defb0e7ec29f5f58a55aeef7bf7/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:31fd66405eaf47bb62e8cd575dc621c56c668f27d46a61d975a249930dd5e2a4", size = 162022, upload-time = "2025-10-14T04:40:44.547Z" },
-    { url = "https://files.pythonhosted.org/packages/80/e6/7aab83774f5d2bca81f42ac58d04caf44f0cc2b65fc6db2b3b2e8a05f3b3/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:0d3d8f15c07f86e9ff82319b3d9ef6f4bf907608f53fe9d92b28ea9ae3d1fd89", size = 149383, upload-time = "2025-10-14T04:40:46.018Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/e8/b289173b4edae05c0dde07f69f8db476a0b511eac556dfe0d6bda3c43384/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:9f7fcd74d410a36883701fafa2482a6af2ff5ba96b9a620e9e0721e28ead5569", size = 159098, upload-time = "2025-10-14T04:40:47.081Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/df/fe699727754cae3f8478493c7f45f777b17c3ef0600e28abfec8619eb49c/charset_normalizer-3.4.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ebf3e58c7ec8a8bed6d66a75d7fb37b55e5015b03ceae72a8e7c74495551e224", size = 152991, upload-time = "2025-10-14T04:40:48.246Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/86/584869fe4ddb6ffa3bd9f491b87a01568797fb9bd8933f557dba9771beaf/charset_normalizer-3.4.4-cp311-cp311-win32.whl", hash = "sha256:eecbc200c7fd5ddb9a7f16c7decb07b566c29fa2161a16cf67b8d068bd21690a", size = 99456, upload-time = "2025-10-14T04:40:49.376Z" },
-    { url = "https://files.pythonhosted.org/packages/65/f6/62fdd5feb60530f50f7e38b4f6a1d5203f4d16ff4f9f0952962c044e919a/charset_normalizer-3.4.4-cp311-cp311-win_amd64.whl", hash = "sha256:5ae497466c7901d54b639cf42d5b8c1b6a4fead55215500d2f486d34db48d016", size = 106978, upload-time = "2025-10-14T04:40:50.844Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/9d/0710916e6c82948b3be62d9d398cb4fcf4e97b56d6a6aeccd66c4b2f2bd5/charset_normalizer-3.4.4-cp311-cp311-win_arm64.whl", hash = "sha256:65e2befcd84bc6f37095f5961e68a6f077bf44946771354a28ad434c2cce0ae1", size = 99969, upload-time = "2025-10-14T04:40:52.272Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/85/1637cd4af66fa687396e757dec650f28025f2a2f5a5531a3208dc0ec43f2/charset_normalizer-3.4.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0a98e6759f854bd25a58a73fa88833fba3b7c491169f86ce1180c948ab3fd394", size = 208425, upload-time = "2025-10-14T04:40:53.353Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/6a/04130023fef2a0d9c62d0bae2649b69f7b7d8d24ea5536feef50551029df/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b5b290ccc2a263e8d185130284f8501e3e36c5e02750fc6b6bdeb2e9e96f1e25", size = 148162, upload-time = "2025-10-14T04:40:54.558Z" },
-    { url = "https://files.pythonhosted.org/packages/78/29/62328d79aa60da22c9e0b9a66539feae06ca0f5a4171ac4f7dc285b83688/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74bb723680f9f7a6234dcf67aea57e708ec1fbdf5699fb91dfd6f511b0a320ef", size = 144558, upload-time = "2025-10-14T04:40:55.677Z" },
-    { url = "https://files.pythonhosted.org/packages/86/bb/b32194a4bf15b88403537c2e120b817c61cd4ecffa9b6876e941c3ee38fe/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f1e34719c6ed0b92f418c7c780480b26b5d9c50349e9a9af7d76bf757530350d", size = 161497, upload-time = "2025-10-14T04:40:57.217Z" },
-    { url = "https://files.pythonhosted.org/packages/19/89/a54c82b253d5b9b111dc74aca196ba5ccfcca8242d0fb64146d4d3183ff1/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2437418e20515acec67d86e12bf70056a33abdacb5cb1655042f6538d6b085a8", size = 159240, upload-time = "2025-10-14T04:40:58.358Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/10/d20b513afe03acc89ec33948320a5544d31f21b05368436d580dec4e234d/charset_normalizer-3.4.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11d694519d7f29d6cd09f6ac70028dba10f92f6cdd059096db198c283794ac86", size = 153471, upload-time = "2025-10-14T04:40:59.468Z" },
-    { url = "https://files.pythonhosted.org/packages/61/fa/fbf177b55bdd727010f9c0a3c49eefa1d10f960e5f09d1d887bf93c2e698/charset_normalizer-3.4.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ac1c4a689edcc530fc9d9aa11f5774b9e2f33f9a0c6a57864e90908f5208d30a", size = 150864, upload-time = "2025-10-14T04:41:00.623Z" },
-    { url = "https://files.pythonhosted.org/packages/05/12/9fbc6a4d39c0198adeebbde20b619790e9236557ca59fc40e0e3cebe6f40/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:21d142cc6c0ec30d2efee5068ca36c128a30b0f2c53c1c07bd78cb6bc1d3be5f", size = 150647, upload-time = "2025-10-14T04:41:01.754Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/1f/6a9a593d52e3e8c5d2b167daf8c6b968808efb57ef4c210acb907c365bc4/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:5dbe56a36425d26d6cfb40ce79c314a2e4dd6211d51d6d2191c00bed34f354cc", size = 145110, upload-time = "2025-10-14T04:41:03.231Z" },
-    { url = "https://files.pythonhosted.org/packages/30/42/9a52c609e72471b0fc54386dc63c3781a387bb4fe61c20231a4ebcd58bdd/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:5bfbb1b9acf3334612667b61bd3002196fe2a1eb4dd74d247e0f2a4d50ec9bbf", size = 162839, upload-time = "2025-10-14T04:41:04.715Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/5b/c0682bbf9f11597073052628ddd38344a3d673fda35a36773f7d19344b23/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:d055ec1e26e441f6187acf818b73564e6e6282709e9bcb5b63f5b23068356a15", size = 150667, upload-time = "2025-10-14T04:41:05.827Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/24/a41afeab6f990cf2daf6cb8c67419b63b48cf518e4f56022230840c9bfb2/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:af2d8c67d8e573d6de5bc30cdb27e9b95e49115cd9baad5ddbd1a6207aaa82a9", size = 160535, upload-time = "2025-10-14T04:41:06.938Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/e5/6a4ce77ed243c4a50a1fecca6aaaab419628c818a49434be428fe24c9957/charset_normalizer-3.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:780236ac706e66881f3b7f2f32dfe90507a09e67d1d454c762cf642e6e1586e0", size = 154816, upload-time = "2025-10-14T04:41:08.101Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/ef/89297262b8092b312d29cdb2517cb1237e51db8ecef2e9af5edbe7b683b1/charset_normalizer-3.4.4-cp312-cp312-win32.whl", hash = "sha256:5833d2c39d8896e4e19b689ffc198f08ea58116bee26dea51e362ecc7cd3ed26", size = 99694, upload-time = "2025-10-14T04:41:09.23Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/2d/1e5ed9dd3b3803994c155cd9aacb60c82c331bad84daf75bcb9c91b3295e/charset_normalizer-3.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:a79cfe37875f822425b89a82333404539ae63dbdddf97f84dcbc3d339aae9525", size = 107131, upload-time = "2025-10-14T04:41:10.467Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/d9/0ed4c7098a861482a7b6a95603edce4c0d9db2311af23da1fb2b75ec26fc/charset_normalizer-3.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:376bec83a63b8021bb5c8ea75e21c4ccb86e7e45ca4eb81146091b56599b80c3", size = 100390, upload-time = "2025-10-14T04:41:11.915Z" },
-    { url = "https://files.pythonhosted.org/packages/97/45/4b3a1239bbacd321068ea6e7ac28875b03ab8bc0aa0966452db17cd36714/charset_normalizer-3.4.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e1f185f86a6f3403aa2420e815904c67b2f9ebc443f045edd0de921108345794", size = 208091, upload-time = "2025-10-14T04:41:13.346Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/62/73a6d7450829655a35bb88a88fca7d736f9882a27eacdca2c6d505b57e2e/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b39f987ae8ccdf0d2642338faf2abb1862340facc796048b604ef14919e55ed", size = 147936, upload-time = "2025-10-14T04:41:14.461Z" },
-    { url = "https://files.pythonhosted.org/packages/89/c5/adb8c8b3d6625bef6d88b251bbb0d95f8205831b987631ab0c8bb5d937c2/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3162d5d8ce1bb98dd51af660f2121c55d0fa541b46dff7bb9b9f86ea1d87de72", size = 144180, upload-time = "2025-10-14T04:41:15.588Z" },
-    { url = "https://files.pythonhosted.org/packages/91/ed/9706e4070682d1cc219050b6048bfd293ccf67b3d4f5a4f39207453d4b99/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:81d5eb2a312700f4ecaa977a8235b634ce853200e828fbadf3a9c50bab278328", size = 161346, upload-time = "2025-10-14T04:41:16.738Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/0d/031f0d95e4972901a2f6f09ef055751805ff541511dc1252ba3ca1f80cf5/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5bd2293095d766545ec1a8f612559f6b40abc0eb18bb2f5d1171872d34036ede", size = 158874, upload-time = "2025-10-14T04:41:17.923Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/83/6ab5883f57c9c801ce5e5677242328aa45592be8a00644310a008d04f922/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a8a8b89589086a25749f471e6a900d3f662d1d3b6e2e59dcecf787b1cc3a1894", size = 153076, upload-time = "2025-10-14T04:41:19.106Z" },
-    { url = "https://files.pythonhosted.org/packages/75/1e/5ff781ddf5260e387d6419959ee89ef13878229732732ee73cdae01800f2/charset_normalizer-3.4.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc7637e2f80d8530ee4a78e878bce464f70087ce73cf7c1caf142416923b98f1", size = 150601, upload-time = "2025-10-14T04:41:20.245Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/57/71be810965493d3510a6ca79b90c19e48696fb1ff964da319334b12677f0/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f8bf04158c6b607d747e93949aa60618b61312fe647a6369f88ce2ff16043490", size = 150376, upload-time = "2025-10-14T04:41:21.398Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/d5/c3d057a78c181d007014feb7e9f2e65905a6c4ef182c0ddf0de2924edd65/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:554af85e960429cf30784dd47447d5125aaa3b99a6f0683589dbd27e2f45da44", size = 144825, upload-time = "2025-10-14T04:41:22.583Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/8c/d0406294828d4976f275ffbe66f00266c4b3136b7506941d87c00cab5272/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:74018750915ee7ad843a774364e13a3db91682f26142baddf775342c3f5b1133", size = 162583, upload-time = "2025-10-14T04:41:23.754Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/24/e2aa1f18c8f15c4c0e932d9287b8609dd30ad56dbe41d926bd846e22fb8d/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c0463276121fdee9c49b98908b3a89c39be45d86d1dbaa22957e38f6321d4ce3", size = 150366, upload-time = "2025-10-14T04:41:25.27Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/5b/1e6160c7739aad1e2df054300cc618b06bf784a7a164b0f238360721ab86/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:362d61fd13843997c1c446760ef36f240cf81d3ebf74ac62652aebaf7838561e", size = 160300, upload-time = "2025-10-14T04:41:26.725Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/10/f882167cd207fbdd743e55534d5d9620e095089d176d55cb22d5322f2afd/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9a26f18905b8dd5d685d6d07b0cdf98a79f3c7a918906af7cc143ea2e164c8bc", size = 154465, upload-time = "2025-10-14T04:41:28.322Z" },
-    { url = "https://files.pythonhosted.org/packages/89/66/c7a9e1b7429be72123441bfdbaf2bc13faab3f90b933f664db506dea5915/charset_normalizer-3.4.4-cp313-cp313-win32.whl", hash = "sha256:9b35f4c90079ff2e2edc5b26c0c77925e5d2d255c42c74fdb70fb49b172726ac", size = 99404, upload-time = "2025-10-14T04:41:29.95Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/26/b9924fa27db384bdcd97ab83b4f0a8058d96ad9626ead570674d5e737d90/charset_normalizer-3.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:b435cba5f4f750aa6c0a0d92c541fb79f69a387c91e61f1795227e4ed9cece14", size = 107092, upload-time = "2025-10-14T04:41:31.188Z" },
-    { url = "https://files.pythonhosted.org/packages/af/8f/3ed4bfa0c0c72a7ca17f0380cd9e4dd842b09f664e780c13cff1dcf2ef1b/charset_normalizer-3.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:542d2cee80be6f80247095cc36c418f7bddd14f4a6de45af91dfad36d817bba2", size = 100408, upload-time = "2025-10-14T04:41:32.624Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/35/7051599bd493e62411d6ede36fd5af83a38f37c4767b92884df7301db25d/charset_normalizer-3.4.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:da3326d9e65ef63a817ecbcc0df6e94463713b754fe293eaa03da99befb9a5bd", size = 207746, upload-time = "2025-10-14T04:41:33.773Z" },
-    { url = "https://files.pythonhosted.org/packages/10/9a/97c8d48ef10d6cd4fcead2415523221624bf58bcf68a802721a6bc807c8f/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8af65f14dc14a79b924524b1e7fffe304517b2bff5a58bf64f30b98bbc5079eb", size = 147889, upload-time = "2025-10-14T04:41:34.897Z" },
-    { url = "https://files.pythonhosted.org/packages/10/bf/979224a919a1b606c82bd2c5fa49b5c6d5727aa47b4312bb27b1734f53cd/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74664978bb272435107de04e36db5a9735e78232b85b77d45cfb38f758efd33e", size = 143641, upload-time = "2025-10-14T04:41:36.116Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/33/0ad65587441fc730dc7bd90e9716b30b4702dc7b617e6ba4997dc8651495/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:752944c7ffbfdd10c074dc58ec2d5a8a4cd9493b314d367c14d24c17684ddd14", size = 160779, upload-time = "2025-10-14T04:41:37.229Z" },
-    { url = "https://files.pythonhosted.org/packages/67/ed/331d6b249259ee71ddea93f6f2f0a56cfebd46938bde6fcc6f7b9a3d0e09/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d1f13550535ad8cff21b8d757a3257963e951d96e20ec82ab44bc64aeb62a191", size = 159035, upload-time = "2025-10-14T04:41:38.368Z" },
-    { url = "https://files.pythonhosted.org/packages/67/ff/f6b948ca32e4f2a4576aa129d8bed61f2e0543bf9f5f2b7fc3758ed005c9/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecaae4149d99b1c9e7b88bb03e3221956f68fd6d50be2ef061b2381b61d20838", size = 152542, upload-time = "2025-10-14T04:41:39.862Z" },
-    { url = "https://files.pythonhosted.org/packages/16/85/276033dcbcc369eb176594de22728541a925b2632f9716428c851b149e83/charset_normalizer-3.4.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cb6254dc36b47a990e59e1068afacdcd02958bdcce30bb50cc1700a8b9d624a6", size = 149524, upload-time = "2025-10-14T04:41:41.319Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/f2/6a2a1f722b6aba37050e626530a46a68f74e63683947a8acff92569f979a/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c8ae8a0f02f57a6e61203a31428fa1d677cbe50c93622b4149d5c0f319c1d19e", size = 150395, upload-time = "2025-10-14T04:41:42.539Z" },
-    { url = "https://files.pythonhosted.org/packages/60/bb/2186cb2f2bbaea6338cad15ce23a67f9b0672929744381e28b0592676824/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:47cc91b2f4dd2833fddaedd2893006b0106129d4b94fdb6af1f4ce5a9965577c", size = 143680, upload-time = "2025-10-14T04:41:43.661Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/a5/bf6f13b772fbb2a90360eb620d52ed8f796f3c5caee8398c3b2eb7b1c60d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:82004af6c302b5d3ab2cfc4cc5f29db16123b1a8417f2e25f9066f91d4411090", size = 162045, upload-time = "2025-10-14T04:41:44.821Z" },
-    { url = "https://files.pythonhosted.org/packages/df/c5/d1be898bf0dc3ef9030c3825e5d3b83f2c528d207d246cbabe245966808d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b7d8f6c26245217bd2ad053761201e9f9680f8ce52f0fcd8d0755aeae5b2152", size = 149687, upload-time = "2025-10-14T04:41:46.442Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/42/90c1f7b9341eef50c8a1cb3f098ac43b0508413f33affd762855f67a410e/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:799a7a5e4fb2d5898c60b640fd4981d6a25f1c11790935a44ce38c54e985f828", size = 160014, upload-time = "2025-10-14T04:41:47.631Z" },
-    { url = "https://files.pythonhosted.org/packages/76/be/4d3ee471e8145d12795ab655ece37baed0929462a86e72372fd25859047c/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:99ae2cffebb06e6c22bdc25801d7b30f503cc87dbd283479e7b606f70aff57ec", size = 154044, upload-time = "2025-10-14T04:41:48.81Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/6f/8f7af07237c34a1defe7defc565a9bc1807762f672c0fde711a4b22bf9c0/charset_normalizer-3.4.4-cp314-cp314-win32.whl", hash = "sha256:f9d332f8c2a2fcbffe1378594431458ddbef721c1769d78e2cbc06280d8155f9", size = 99940, upload-time = "2025-10-14T04:41:49.946Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/51/8ade005e5ca5b0d80fb4aff72a3775b325bdc3d27408c8113811a7cbe640/charset_normalizer-3.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c", size = 107104, upload-time = "2025-10-14T04:41:51.051Z" },
-    { url = "https://files.pythonhosted.org/packages/da/5f/6b8f83a55bb8278772c5ae54a577f3099025f9ade59d0136ac24a0df4bde/charset_normalizer-3.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2", size = 100743, upload-time = "2025-10-14T04:41:52.122Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
 ]
 
 [[package]]
 name = "click"
-version = "8.3.0"
+version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/61/de6cd827efad202d7057d93e0fed9294b96952e188f7384832791c7b2254/click-8.3.0.tar.gz", hash = "sha256:e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4", size = 276943, upload-time = "2025-09-18T17:32:23.696Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/d3/9dcc0f5797f070ec8edf30fbadfb200e71d9db6b84d211e3b2085a7589a0/click-8.3.0-py3-none-any.whl", hash = "sha256:9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc", size = 107295, upload-time = "2025-09-18T17:32:22.42Z" },
-]
-
-[[package]]
-name = "cloudscraper"
-version = "1.2.71"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyparsing" },
-    { name = "requests" },
-    { name = "requests-toolbelt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ac/25/6d0481860583f44953bd791de0b7c4f6d7ead7223f8a17e776247b34a5b4/cloudscraper-1.2.71.tar.gz", hash = "sha256:429c6e8aa6916d5bad5c8a5eac50f3ea53c9ac22616f6cb21b18dcc71517d0d3", size = 93261, upload-time = "2023-04-25T23:20:19.467Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/97/fc88803a451029688dffd7eb446dc1b529657577aec13aceff1cc9628c5d/cloudscraper-1.2.71-py2.py3-none-any.whl", hash = "sha256:76f50ca529ed2279e220837befdec892626f9511708e200d48d5bb76ded679b0", size = 99652, upload-time = "2023-04-25T23:20:15.974Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
 ]
 
 [[package]]
@@ -165,6 +59,63 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/3f/dbf99fb14bfeb88c28f16729215478c0e265cacd6dc22270c8f31bb6892f/greenlet-3.5.0.tar.gz", hash = "sha256:d419647372241bc68e957bf38d5c1f98852155e4146bd1e4121adea81f4f01e4", size = 196995, upload-time = "2026-04-27T13:37:15.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/0f/a91f143f356523ff682309732b175765a9bc2836fd7c081c2c67fedc1ad4/greenlet-3.5.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:8f1cc966c126639cd152fdaa52624d2655f492faa79e013fea161de3e6dda082", size = 284726, upload-time = "2026-04-27T12:20:51.402Z" },
+    { url = "https://files.pythonhosted.org/packages/95/82/800646c7ffc5dbabd75ddd2f6b519bb898c0c9c969e5d0473bfe5d20bcce/greenlet-3.5.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:362624e6a8e5bca3b8233e45eef33903a100e9539a2b995c364d595dbc4018b3", size = 604264, upload-time = "2026-04-27T12:52:39.494Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ac/354867c0bba812fc33b15bc55aedafedd0aee3c7dd91dfca22444157dc0c/greenlet-3.5.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5ecd83806b0f4c2f53b1018e0005cd82269ea01d42befc0368730028d850ed1c", size = 616099, upload-time = "2026-04-27T12:59:39.623Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ab/192090c4a5b30df148c22bf4b8895457d739a7c7c5a7b9c41e5dd7f537f2/greenlet-3.5.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa94cb2288681e3a11645958f1871d48ee9211bd2f66628fdace505927d6e564", size = 623976, upload-time = "2026-04-27T13:02:37.363Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b0/815bece7399e01cadb69014219eebd0042339875c59a59b0820a46ece356/greenlet-3.5.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0ff251e9a0279522e62f6176412869395a64ddf2b5c5f782ff609a8216a4e662", size = 615198, upload-time = "2026-04-27T12:25:25.928Z" },
+    { url = "https://files.pythonhosted.org/packages/24/11/05eb2b9b188c6df7d68a89c99134d644a7af616a40b9808e8e6ced315d5d/greenlet-3.5.0-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:64d6ac45f7271f48e45f67c95b54ef73534c52ec041fcda8edf520c6d811f4bc", size = 418379, upload-time = "2026-04-27T13:05:12.755Z" },
+    { url = "https://files.pythonhosted.org/packages/10/80/3b2c0a895d6698f6ddb31b07942ebfa982f3e30888bc5546a5b5990de8b2/greenlet-3.5.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6d874e79afd41a96e11ff4c5d0bc90a80973e476fda1c2c64985667397df432b", size = 1574927, upload-time = "2026-04-27T12:53:25.81Z" },
+    { url = "https://files.pythonhosted.org/packages/44/0e/f354af514a4c61454dbc68e44d47544a5a4d6317e30b77ddfa3a09f4c5f3/greenlet-3.5.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0ed006e4b86c59de7467eb2601cd1b77b5a7d657d1ee55e30fe30d76451edba4", size = 1642683, upload-time = "2026-04-27T12:25:23.9Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/6a/87f38255201e993a1915265ebb80cd7c2c78b04a45744995abbf6b259fd8/greenlet-3.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:703cb211b820dbffbbc55a16bfc6e4583a6e6e990f33a119d2cc8b83211119c8", size = 238115, upload-time = "2026-04-27T12:21:48.845Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f8/450fe3c5938fa737ea4d22699772e6e34e8e24431a47bf4e8a1ceed4a98e/greenlet-3.5.0-cp311-cp311-win_arm64.whl", hash = "sha256:6c18dfb59c70f5a94acd271c72e90128c3c776e41e5f07767908c8c1b74ad339", size = 235017, upload-time = "2026-04-27T12:22:26.768Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/32/f2ce6d4cac3e55bc6173f92dbe627e782e1850f89d986c3606feb63aafa7/greenlet-3.5.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:db2910d3c809444e0a20147361f343fe2798e106af8d9d8506f5305302655a9f", size = 286228, upload-time = "2026-04-27T12:20:34.421Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/aa/caed9e5adf742315fc7be2a84196373aab4816e540e38ba0d76cb7584d68/greenlet-3.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ec9ea74e7268ace7f9aab1b1a4e730193fc661b39a993cd91c606c32d4a3628", size = 601775, upload-time = "2026-04-27T12:52:41.045Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/af/90ae08497400a941595d12774447f752d3dfe0fbb012e35b76bc5c0ff37e/greenlet-3.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54d243512da35485fc7a6bf3c178fdda6327a9d6506fcdd62b1abd1e41b2927b", size = 614436, upload-time = "2026-04-27T12:59:41.595Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e9/4eeadf8cb3403ac274245ba75f07844abc7fa5f6787583fc9156ba741e0f/greenlet-3.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:41353ec2ecedf7aa8f682753a41919f8718031a6edac46b8d3dc7ed9e1ceb136", size = 620610, upload-time = "2026-04-27T13:02:39.194Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e0/2e13df68f367e2f9960616927d60857dd7e56aaadd59a47c644216b2f920/greenlet-3.5.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d280a7f5c331622c69f97eb167f33577ff2d1df282c41cd15907fc0a3ca198c", size = 611388, upload-time = "2026-04-27T12:25:28.008Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ef/f913b3c0eb7d26d86a2401c5e1546c9d46b657efee724b06f6f4ac5d8824/greenlet-3.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:58c1c374fe2b3d852f9b6b11a7dff4c85404e51b9a596fd9e89cf904eb09866d", size = 422775, upload-time = "2026-04-27T13:05:14.261Z" },
+    { url = "https://files.pythonhosted.org/packages/82/f7/393c64055132ac0d488ef6be549253b7e6274194863967ddc0bc8f5b87b8/greenlet-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1eb67d5adefb5bd2e182d42678a328979a209e4e82eb93575708185d31d1f588", size = 1570768, upload-time = "2026-04-27T12:53:28.099Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/4b/eaf7735253522cf56d1b74d672a58f54fc114702ceaf05def59aae72f6e1/greenlet-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2628d6c86f6cb0cb45e0c3c54058bbec559f57eaae699447748cb3928150577e", size = 1635983, upload-time = "2026-04-27T12:25:26.903Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/4fb3a0805bd5165da5ebf858da7cc01cce8061674106d2cf5bdab32cbfde/greenlet-3.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:d4d9f0624c775f2dfc56ba54d515a8c771044346852a918b405914f6b19d7fd8", size = 238840, upload-time = "2026-04-27T12:23:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/cb/baa584cb00532126ffe12d9787db0a60c5a4f55c27bfe2666df5d4c30a32/greenlet-3.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:83ed9f27f1680b50e89f40f6df348a290ea234b249a4003d366663a12eab94f2", size = 235615, upload-time = "2026-04-27T12:21:38.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/58/fc576f99037ce19c5aa16628e4c3226b6d1419f72a62c79f5f40576e6eb3/greenlet-3.5.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:5a5ed18de6a0f6cc7087f1563f6bd93fc7df1c19165ca01e9bde5a5dc281d106", size = 285066, upload-time = "2026-04-27T12:23:05.033Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/ba/b28ddbe6bfad6a8ac196ef0e8cff37bc65b79735995b9e410923fffeeb70/greenlet-3.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a717fbc46d8a354fa675f7c1e813485b6ba3885f9bef0cd56e5ba27d758ff5b", size = 604414, upload-time = "2026-04-27T12:52:42.358Z" },
+    { url = "https://files.pythonhosted.org/packages/09/06/4b69f8f0b67603a8be2790e55107a190b376f2627fe0eaf5695d85ffb3cd/greenlet-3.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ddc090c5c1792b10246a78e8c2163ebbe04cf877f9d785c230a7b27b39ad038e", size = 617349, upload-time = "2026-04-27T12:59:43.32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/15/a643b4ecd09969e30b8a150d5919960caae0abe4f5af75ab040b1ab85e78/greenlet-3.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4964101b8585c144cbda5532b1aa644255126c08a265dae90c16e7a0e63aaa9d", size = 623234, upload-time = "2026-04-27T13:02:40.611Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/17/a3918541fd0ddefe024a69de6d16aa7b46d36ac19562adaa63c7fa180eff/greenlet-3.5.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2094acd54b272cb6eae8c03dd87b3fa1820a4cef18d6889c378d503500a1dc13", size = 613927, upload-time = "2026-04-27T12:25:30.28Z" },
+    { url = "https://files.pythonhosted.org/packages/77/18/3b13d5ef1275b0ffaf933b05efa21408ac4ca95823c7411d79682e4fdcff/greenlet-3.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:7022615368890680e67b9965d33f5773aade330d5343bbe25560135aaa849eae", size = 425243, upload-time = "2026-04-27T13:05:15.689Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/e1/bd0af6213c7dd33175d8a462d4c1fe1175124ebed4855bc1475a5b5242c2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5e05ba267789ea87b5a155cf0e810b1ab88bf18e9e8740813945ceb8ee4350ba", size = 1570893, upload-time = "2026-04-27T12:53:29.483Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2a/0789702f864f5382cb476b93d7a9c823c10472658102ccd65f415747d2e2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0ecec963079cd58cbd14723582384f11f166fd58883c15dcbfb342e0bc9b5846", size = 1636060, upload-time = "2026-04-27T12:25:28.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/8f/22bf9df92bbff0eb07842b60f7e63bf7675a9742df628437a9f02d09137f/greenlet-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:728d9667d8f2f586644b748dbd9bb67e50d6a9381767d1357714ea6825bb3bf5", size = 238740, upload-time = "2026-04-27T12:24:01.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/b7/9c5c3d653bd4ff614277c049ac676422e2c557db47b4fe43e6313fc005dc/greenlet-3.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:47422135b1d308c14b2c6e758beedb1acd33bb91679f5670edf77bf46244722b", size = 235525, upload-time = "2026-04-27T12:23:12.308Z" },
+    { url = "https://files.pythonhosted.org/packages/94/5e/a70f31e3e8d961c4ce589c15b28e4225d63704e431a23932a3808cbcc867/greenlet-3.5.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f35807464c4c58c55f0d31dfa83c541a5615d825c2fe3d2b95360cf7c4e3c0a8", size = 285564, upload-time = "2026-04-27T12:23:08.555Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a6/046c0a28e21833e4086918218cfb3d8bed51c075a1b700f20b9d7861c0f4/greenlet-3.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55fa7ea52771be44af0de27d8b80c02cd18c2c3cddde6c847ecebdf72418b6a1", size = 651166, upload-time = "2026-04-27T12:52:43.644Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f8/4af27f71c5ff32a7fbc516adb46370d9c4ae2bc7bd3dc7d066ac542b4b15/greenlet-3.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a97e4821aa710603f94de0da25f25096454d78ffdace5dc77f3a006bc01abba3", size = 663792, upload-time = "2026-04-27T12:59:44.93Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/89/2dadb89793c37ee8b4c237857188293e9060dc085f19845c292e00f8e091/greenlet-3.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bf2d8a80bec89ab46221ae45c5373d5ba0bd36c19aa8508e85c6cd7e5106cd37", size = 668086, upload-time = "2026-04-27T13:02:42.314Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/59/1bd6d7428d6ed9106efbb8c52310c60fd04f6672490f452aeaa3829aa436/greenlet-3.5.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f52a464e4ed91780bdfbbdd2b97197f3accaa629b98c200f4dffada759f3ae7", size = 660933, upload-time = "2026-04-27T12:25:33.276Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/75722be7e26a2af4cbd2dc35b0ed382dacf9394b7e75551f76ed1abe87f2/greenlet-3.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:1bae92a1dd94c5f9d9493c3a212dd874c202442047cf96446412c862feca83a2", size = 470799, upload-time = "2026-04-27T13:05:17.094Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e4/b903e5a5fae1e8a28cdd32a0cfbfd560b668c25b692f67768822ddc5f40f/greenlet-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:762612baf1161ccb8437c0161c668a688223cba28e1bf038f4eb47b13e39ccdf", size = 1618401, upload-time = "2026-04-27T12:53:31.062Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/e3/5ec408a329acb854fb607a122e1ee5fb3ff649f9a97952948a90803c0d8e/greenlet-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:57a43c6079a89713522bc4bcb9f75070ecf5d3dbad7792bfe42239362cbf2a16", size = 1682038, upload-time = "2026-04-27T12:25:31.838Z" },
+    { url = "https://files.pythonhosted.org/packages/91/20/6b165108058767ee643c55c5c4904d591a830ee2b3c7dbd359828fbc829f/greenlet-3.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bc59be3945ae9750b9e7d45067d01ae3fe90ea5f9ade99239dabdd6e28a5033", size = 239835, upload-time = "2026-04-27T12:24:54.136Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/62/1c498375cee177b55d980c1db319f26470e5309e54698c8f8fc06c0fd539/greenlet-3.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:a96fcee45e03fe30a62669fd16ab5c9d3c172660d3085605cb1e2d1280d3c988", size = 236862, upload-time = "2026-04-27T12:23:24.957Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a8/4522939255bb5409af4e87132f915446bf3622c2c292d14d3c38d128ae82/greenlet-3.5.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a10a732421ab4fec934783ce3e54763470d0181db6e3468f9103a275c3ed1853", size = 293614, upload-time = "2026-04-27T12:24:12.874Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5e/8744c52e2c027b5a8772a01561934c8835f869733e101f62075c60430340/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fc391b1566f2907d17aaebe78f8855dc45675159a775fcf9e61f8ee0078e87f", size = 650723, upload-time = "2026-04-27T12:52:45.412Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ef/7b4c39c03cf46ceca512c5d3f914afd85aa30b2cc9a93015b0dd73e4be6c/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:680bd0e7ad5e8daa8a4aa89f68fd6adc834b8a8036dc256533f7e08f4a4b01f7", size = 656529, upload-time = "2026-04-27T12:59:46.295Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5c/0602239503b124b70e39355cbdb39361ecfe65b87a5f2f63752c32f5286f/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1aa4ce8debcd4ea7fb2e150f3036588c41493d1d52c43538924ae1819003f4ce", size = 657015, upload-time = "2026-04-27T13:02:43.973Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/c7768f352f5c010f92064d0063f987e7dc0cd290a6d92a34109015ce4aa1/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddb36c7d6c9c0a65f18c7258634e0c416c6ab59caac8c987b96f80c2ebda0112", size = 654364, upload-time = "2026-04-27T12:25:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/38/51/8699f865f125dc952384cb432b0f7138aa4d8f2969a7d12d0df5b94d054d/greenlet-3.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:728a73687e39ae9ca34e4694cbf2f049d3fbc7174639468d0f67200a97d8f9e2", size = 488275, upload-time = "2026-04-27T13:05:18.28Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/d0/079ebe12e4b1fc758857ce5be1a5e73f06870f2101e52611d1e71925ce54/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2", size = 1614204, upload-time = "2026-04-27T12:53:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/89/6c2fb63df3596552d20e58fb4d96669243388cf680cff222758812c7bfaa/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2", size = 1675480, upload-time = "2026-04-27T12:25:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/77ee8a6c1564fc345a491a4e85b3bf360e4cf26eac98c4532d2fdb96e01f/greenlet-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86", size = 245324, upload-time = "2026-04-27T12:24:40.295Z" },
 ]
 
 [[package]]
@@ -206,11 +157,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]
@@ -223,117 +174,15 @@ wheels = [
 ]
 
 [[package]]
-name = "lxml"
-version = "6.0.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/aa/88/262177de60548e5a2bfc46ad28232c9e9cbde697bd94132aeb80364675cb/lxml-6.0.2.tar.gz", hash = "sha256:cd79f3367bd74b317dda655dc8fcfa304d9eb6e4fb06b7168c5cf27f96e0cd62", size = 4073426, upload-time = "2025-09-22T04:04:59.287Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/d5/becbe1e2569b474a23f0c672ead8a29ac50b2dc1d5b9de184831bda8d14c/lxml-6.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:13e35cbc684aadf05d8711a5d1b5857c92e5e580efa9a0d2be197199c8def607", size = 8634365, upload-time = "2025-09-22T04:00:45.672Z" },
-    { url = "https://files.pythonhosted.org/packages/28/66/1ced58f12e804644426b85d0bb8a4478ca77bc1761455da310505f1a3526/lxml-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3b1675e096e17c6fe9c0e8c81434f5736c0739ff9ac6123c87c2d452f48fc938", size = 4650793, upload-time = "2025-09-22T04:00:47.783Z" },
-    { url = "https://files.pythonhosted.org/packages/11/84/549098ffea39dfd167e3f174b4ce983d0eed61f9d8d25b7bf2a57c3247fc/lxml-6.0.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac6e5811ae2870953390452e3476694196f98d447573234592d30488147404d", size = 4944362, upload-time = "2025-09-22T04:00:49.845Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/bd/f207f16abf9749d2037453d56b643a7471d8fde855a231a12d1e095c4f01/lxml-6.0.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5aa0fc67ae19d7a64c3fe725dc9a1bb11f80e01f78289d05c6f62545affec438", size = 5083152, upload-time = "2025-09-22T04:00:51.709Z" },
-    { url = "https://files.pythonhosted.org/packages/15/ae/bd813e87d8941d52ad5b65071b1affb48da01c4ed3c9c99e40abb266fbff/lxml-6.0.2-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de496365750cc472b4e7902a485d3f152ecf57bd3ba03ddd5578ed8ceb4c5964", size = 5023539, upload-time = "2025-09-22T04:00:53.593Z" },
-    { url = "https://files.pythonhosted.org/packages/02/cd/9bfef16bd1d874fbe0cb51afb00329540f30a3283beb9f0780adbb7eec03/lxml-6.0.2-cp311-cp311-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:200069a593c5e40b8f6fc0d84d86d970ba43138c3e68619ffa234bc9bb806a4d", size = 5344853, upload-time = "2025-09-22T04:00:55.524Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/89/ea8f91594bc5dbb879734d35a6f2b0ad50605d7fb419de2b63d4211765cc/lxml-6.0.2-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d2de809c2ee3b888b59f995625385f74629707c9355e0ff856445cdcae682b7", size = 5225133, upload-time = "2025-09-22T04:00:57.269Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/37/9c735274f5dbec726b2db99b98a43950395ba3d4a1043083dba2ad814170/lxml-6.0.2-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:b2c3da8d93cf5db60e8858c17684c47d01fee6405e554fb55018dd85fc23b178", size = 4677944, upload-time = "2025-09-22T04:00:59.052Z" },
-    { url = "https://files.pythonhosted.org/packages/20/28/7dfe1ba3475d8bfca3878365075abe002e05d40dfaaeb7ec01b4c587d533/lxml-6.0.2-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:442de7530296ef5e188373a1ea5789a46ce90c4847e597856570439621d9c553", size = 5284535, upload-time = "2025-09-22T04:01:01.335Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/cf/5f14bc0de763498fc29510e3532bf2b4b3a1c1d5d0dff2e900c16ba021ef/lxml-6.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2593c77efde7bfea7f6389f1ab249b15ed4aa5bc5cb5131faa3b843c429fbedb", size = 5067343, upload-time = "2025-09-22T04:01:03.13Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/b0/bb8275ab5472f32b28cfbbcc6db7c9d092482d3439ca279d8d6fa02f7025/lxml-6.0.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:3e3cb08855967a20f553ff32d147e14329b3ae70ced6edc2f282b94afbc74b2a", size = 4725419, upload-time = "2025-09-22T04:01:05.013Z" },
-    { url = "https://files.pythonhosted.org/packages/25/4c/7c222753bc72edca3b99dbadba1b064209bc8ed4ad448af990e60dcce462/lxml-6.0.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:2ed6c667fcbb8c19c6791bbf40b7268ef8ddf5a96940ba9404b9f9a304832f6c", size = 5275008, upload-time = "2025-09-22T04:01:07.327Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/8c/478a0dc6b6ed661451379447cdbec77c05741a75736d97e5b2b729687828/lxml-6.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b8f18914faec94132e5b91e69d76a5c1d7b0c73e2489ea8929c4aaa10b76bbf7", size = 5248906, upload-time = "2025-09-22T04:01:09.452Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/d9/5be3a6ab2784cdf9accb0703b65e1b64fcdd9311c9f007630c7db0cfcce1/lxml-6.0.2-cp311-cp311-win32.whl", hash = "sha256:6605c604e6daa9e0d7f0a2137bdc47a2e93b59c60a65466353e37f8272f47c46", size = 3610357, upload-time = "2025-09-22T04:01:11.102Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/7d/ca6fb13349b473d5732fb0ee3eec8f6c80fc0688e76b7d79c1008481bf1f/lxml-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e5867f2651016a3afd8dd2c8238baa66f1e2802f44bc17e236f547ace6647078", size = 4036583, upload-time = "2025-09-22T04:01:12.766Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/a2/51363b5ecd3eab46563645f3a2c3836a2fc67d01a1b87c5017040f39f567/lxml-6.0.2-cp311-cp311-win_arm64.whl", hash = "sha256:4197fb2534ee05fd3e7afaab5d8bfd6c2e186f65ea7f9cd6a82809c887bd1285", size = 3680591, upload-time = "2025-09-22T04:01:14.874Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/c8/8ff2bc6b920c84355146cd1ab7d181bc543b89241cfb1ebee824a7c81457/lxml-6.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a59f5448ba2ceccd06995c95ea59a7674a10de0810f2ce90c9006f3cbc044456", size = 8661887, upload-time = "2025-09-22T04:01:17.265Z" },
-    { url = "https://files.pythonhosted.org/packages/37/6f/9aae1008083bb501ef63284220ce81638332f9ccbfa53765b2b7502203cf/lxml-6.0.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e8113639f3296706fbac34a30813929e29247718e88173ad849f57ca59754924", size = 4667818, upload-time = "2025-09-22T04:01:19.688Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/ca/31fb37f99f37f1536c133476674c10b577e409c0a624384147653e38baf2/lxml-6.0.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a8bef9b9825fa8bc816a6e641bb67219489229ebc648be422af695f6e7a4fa7f", size = 4950807, upload-time = "2025-09-22T04:01:21.487Z" },
-    { url = "https://files.pythonhosted.org/packages/da/87/f6cb9442e4bada8aab5ae7e1046264f62fdbeaa6e3f6211b93f4c0dd97f1/lxml-6.0.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:65ea18d710fd14e0186c2f973dc60bb52039a275f82d3c44a0e42b43440ea534", size = 5109179, upload-time = "2025-09-22T04:01:23.32Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/20/a7760713e65888db79bbae4f6146a6ae5c04e4a204a3c48896c408cd6ed2/lxml-6.0.2-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c371aa98126a0d4c739ca93ceffa0fd7a5d732e3ac66a46e74339acd4d334564", size = 5023044, upload-time = "2025-09-22T04:01:25.118Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/b0/7e64e0460fcb36471899f75831509098f3fd7cd02a3833ac517433cb4f8f/lxml-6.0.2-cp312-cp312-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:700efd30c0fa1a3581d80a748157397559396090a51d306ea59a70020223d16f", size = 5359685, upload-time = "2025-09-22T04:01:27.398Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/e1/e5df362e9ca4e2f48ed6411bd4b3a0ae737cc842e96877f5bf9428055ab4/lxml-6.0.2-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c33e66d44fe60e72397b487ee92e01da0d09ba2d66df8eae42d77b6d06e5eba0", size = 5654127, upload-time = "2025-09-22T04:01:29.629Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/d1/232b3309a02d60f11e71857778bfcd4acbdb86c07db8260caf7d008b08f8/lxml-6.0.2-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90a345bbeaf9d0587a3aaffb7006aa39ccb6ff0e96a57286c0cb2fd1520ea192", size = 5253958, upload-time = "2025-09-22T04:01:31.535Z" },
-    { url = "https://files.pythonhosted.org/packages/35/35/d955a070994725c4f7d80583a96cab9c107c57a125b20bb5f708fe941011/lxml-6.0.2-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:064fdadaf7a21af3ed1dcaa106b854077fbeada827c18f72aec9346847cd65d0", size = 4711541, upload-time = "2025-09-22T04:01:33.801Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/be/667d17363b38a78c4bd63cfd4b4632029fd68d2c2dc81f25ce9eb5224dd5/lxml-6.0.2-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fbc74f42c3525ac4ffa4b89cbdd00057b6196bcefe8bce794abd42d33a018092", size = 5267426, upload-time = "2025-09-22T04:01:35.639Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/47/62c70aa4a1c26569bc958c9ca86af2bb4e1f614e8c04fb2989833874f7ae/lxml-6.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6ddff43f702905a4e32bc24f3f2e2edfe0f8fde3277d481bffb709a4cced7a1f", size = 5064917, upload-time = "2025-09-22T04:01:37.448Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/55/6ceddaca353ebd0f1908ef712c597f8570cc9c58130dbb89903198e441fd/lxml-6.0.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:6da5185951d72e6f5352166e3da7b0dc27aa70bd1090b0eb3f7f7212b53f1bb8", size = 4788795, upload-time = "2025-09-22T04:01:39.165Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/e8/fd63e15da5e3fd4c2146f8bbb3c14e94ab850589beab88e547b2dbce22e1/lxml-6.0.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:57a86e1ebb4020a38d295c04fc79603c7899e0df71588043eb218722dabc087f", size = 5676759, upload-time = "2025-09-22T04:01:41.506Z" },
-    { url = "https://files.pythonhosted.org/packages/76/47/b3ec58dc5c374697f5ba37412cd2728f427d056315d124dd4b61da381877/lxml-6.0.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2047d8234fe735ab77802ce5f2297e410ff40f5238aec569ad7c8e163d7b19a6", size = 5255666, upload-time = "2025-09-22T04:01:43.363Z" },
-    { url = "https://files.pythonhosted.org/packages/19/93/03ba725df4c3d72afd9596eef4a37a837ce8e4806010569bedfcd2cb68fd/lxml-6.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6f91fd2b2ea15a6800c8e24418c0775a1694eefc011392da73bc6cef2623b322", size = 5277989, upload-time = "2025-09-22T04:01:45.215Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/80/c06de80bfce881d0ad738576f243911fccf992687ae09fd80b734712b39c/lxml-6.0.2-cp312-cp312-win32.whl", hash = "sha256:3ae2ce7d6fedfb3414a2b6c5e20b249c4c607f72cb8d2bb7cc9c6ec7c6f4e849", size = 3611456, upload-time = "2025-09-22T04:01:48.243Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/d7/0cdfb6c3e30893463fb3d1e52bc5f5f99684a03c29a0b6b605cfae879cd5/lxml-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:72c87e5ee4e58a8354fb9c7c84cbf95a1c8236c127a5d1b7683f04bed8361e1f", size = 4011793, upload-time = "2025-09-22T04:01:50.042Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/7b/93c73c67db235931527301ed3785f849c78991e2e34f3fd9a6663ffda4c5/lxml-6.0.2-cp312-cp312-win_arm64.whl", hash = "sha256:61cb10eeb95570153e0c0e554f58df92ecf5109f75eacad4a95baa709e26c3d6", size = 3672836, upload-time = "2025-09-22T04:01:52.145Z" },
-    { url = "https://files.pythonhosted.org/packages/53/fd/4e8f0540608977aea078bf6d79f128e0e2c2bba8af1acf775c30baa70460/lxml-6.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9b33d21594afab46f37ae58dfadd06636f154923c4e8a4d754b0127554eb2e77", size = 8648494, upload-time = "2025-09-22T04:01:54.242Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/f4/2a94a3d3dfd6c6b433501b8d470a1960a20ecce93245cf2db1706adf6c19/lxml-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6c8963287d7a4c5c9a432ff487c52e9c5618667179c18a204bdedb27310f022f", size = 4661146, upload-time = "2025-09-22T04:01:56.282Z" },
-    { url = "https://files.pythonhosted.org/packages/25/2e/4efa677fa6b322013035d38016f6ae859d06cac67437ca7dc708a6af7028/lxml-6.0.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1941354d92699fb5ffe6ed7b32f9649e43c2feb4b97205f75866f7d21aa91452", size = 4946932, upload-time = "2025-09-22T04:01:58.989Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/0f/526e78a6d38d109fdbaa5049c62e1d32fdd70c75fb61c4eadf3045d3d124/lxml-6.0.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bb2f6ca0ae2d983ded09357b84af659c954722bbf04dea98030064996d156048", size = 5100060, upload-time = "2025-09-22T04:02:00.812Z" },
-    { url = "https://files.pythonhosted.org/packages/81/76/99de58d81fa702cc0ea7edae4f4640416c2062813a00ff24bd70ac1d9c9b/lxml-6.0.2-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eb2a12d704f180a902d7fa778c6d71f36ceb7b0d317f34cdc76a5d05aa1dd1df", size = 5019000, upload-time = "2025-09-22T04:02:02.671Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/35/9e57d25482bc9a9882cb0037fdb9cc18f4b79d85df94fa9d2a89562f1d25/lxml-6.0.2-cp313-cp313-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:6ec0e3f745021bfed19c456647f0298d60a24c9ff86d9d051f52b509663feeb1", size = 5348496, upload-time = "2025-09-22T04:02:04.904Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/8e/cb99bd0b83ccc3e8f0f528e9aa1f7a9965dfec08c617070c5db8d63a87ce/lxml-6.0.2-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:846ae9a12d54e368933b9759052d6206a9e8b250291109c48e350c1f1f49d916", size = 5643779, upload-time = "2025-09-22T04:02:06.689Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/34/9e591954939276bb679b73773836c6684c22e56d05980e31d52a9a8deb18/lxml-6.0.2-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ef9266d2aa545d7374938fb5c484531ef5a2ec7f2d573e62f8ce722c735685fd", size = 5244072, upload-time = "2025-09-22T04:02:08.587Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/27/b29ff065f9aaca443ee377aff699714fcbffb371b4fce5ac4ca759e436d5/lxml-6.0.2-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:4077b7c79f31755df33b795dc12119cb557a0106bfdab0d2c2d97bd3cf3dffa6", size = 4718675, upload-time = "2025-09-22T04:02:10.783Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/9f/f756f9c2cd27caa1a6ef8c32ae47aadea697f5c2c6d07b0dae133c244fbe/lxml-6.0.2-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a7c5d5e5f1081955358533be077166ee97ed2571d6a66bdba6ec2f609a715d1a", size = 5255171, upload-time = "2025-09-22T04:02:12.631Z" },
-    { url = "https://files.pythonhosted.org/packages/61/46/bb85ea42d2cb1bd8395484fd72f38e3389611aa496ac7772da9205bbda0e/lxml-6.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8f8d0cbd0674ee89863a523e6994ac25fd5be9c8486acfc3e5ccea679bad2679", size = 5057175, upload-time = "2025-09-22T04:02:14.718Z" },
-    { url = "https://files.pythonhosted.org/packages/95/0c/443fc476dcc8e41577f0af70458c50fe299a97bb6b7505bb1ae09aa7f9ac/lxml-6.0.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:2cbcbf6d6e924c28f04a43f3b6f6e272312a090f269eff68a2982e13e5d57659", size = 4785688, upload-time = "2025-09-22T04:02:16.957Z" },
-    { url = "https://files.pythonhosted.org/packages/48/78/6ef0b359d45bb9697bc5a626e1992fa5d27aa3f8004b137b2314793b50a0/lxml-6.0.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:dfb874cfa53340009af6bdd7e54ebc0d21012a60a4e65d927c2e477112e63484", size = 5660655, upload-time = "2025-09-22T04:02:18.815Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/ea/e1d33808f386bc1339d08c0dcada6e4712d4ed8e93fcad5f057070b7988a/lxml-6.0.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:fb8dae0b6b8b7f9e96c26fdd8121522ce5de9bb5538010870bd538683d30e9a2", size = 5247695, upload-time = "2025-09-22T04:02:20.593Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/47/eba75dfd8183673725255247a603b4ad606f4ae657b60c6c145b381697da/lxml-6.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:358d9adae670b63e95bc59747c72f4dc97c9ec58881d4627fe0120da0f90d314", size = 5269841, upload-time = "2025-09-22T04:02:22.489Z" },
-    { url = "https://files.pythonhosted.org/packages/76/04/5c5e2b8577bc936e219becb2e98cdb1aca14a4921a12995b9d0c523502ae/lxml-6.0.2-cp313-cp313-win32.whl", hash = "sha256:e8cd2415f372e7e5a789d743d133ae474290a90b9023197fd78f32e2dc6873e2", size = 3610700, upload-time = "2025-09-22T04:02:24.465Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/0a/4643ccc6bb8b143e9f9640aa54e38255f9d3b45feb2cbe7ae2ca47e8782e/lxml-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:b30d46379644fbfc3ab81f8f82ae4de55179414651f110a1514f0b1f8f6cb2d7", size = 4010347, upload-time = "2025-09-22T04:02:26.286Z" },
-    { url = "https://files.pythonhosted.org/packages/31/ef/dcf1d29c3f530577f61e5fe2f1bd72929acf779953668a8a47a479ae6f26/lxml-6.0.2-cp313-cp313-win_arm64.whl", hash = "sha256:13dcecc9946dca97b11b7c40d29fba63b55ab4170d3c0cf8c0c164343b9bfdcf", size = 3671248, upload-time = "2025-09-22T04:02:27.918Z" },
-    { url = "https://files.pythonhosted.org/packages/03/15/d4a377b385ab693ce97b472fe0c77c2b16ec79590e688b3ccc71fba19884/lxml-6.0.2-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:b0c732aa23de8f8aec23f4b580d1e52905ef468afb4abeafd3fec77042abb6fe", size = 8659801, upload-time = "2025-09-22T04:02:30.113Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/e8/c128e37589463668794d503afaeb003987373c5f94d667124ffd8078bbd9/lxml-6.0.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4468e3b83e10e0317a89a33d28f7aeba1caa4d1a6fd457d115dd4ffe90c5931d", size = 4659403, upload-time = "2025-09-22T04:02:32.119Z" },
-    { url = "https://files.pythonhosted.org/packages/00/ce/74903904339decdf7da7847bb5741fc98a5451b42fc419a86c0c13d26fe2/lxml-6.0.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:abd44571493973bad4598a3be7e1d807ed45aa2adaf7ab92ab7c62609569b17d", size = 4966974, upload-time = "2025-09-22T04:02:34.155Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/d3/131dec79ce61c5567fecf82515bd9bc36395df42501b50f7f7f3bd065df0/lxml-6.0.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:370cd78d5855cfbffd57c422851f7d3864e6ae72d0da615fca4dad8c45d375a5", size = 5102953, upload-time = "2025-09-22T04:02:36.054Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/ea/a43ba9bb750d4ffdd885f2cd333572f5bb900cd2408b67fdda07e85978a0/lxml-6.0.2-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:901e3b4219fa04ef766885fb40fa516a71662a4c61b80c94d25336b4934b71c0", size = 5055054, upload-time = "2025-09-22T04:02:38.154Z" },
-    { url = "https://files.pythonhosted.org/packages/60/23/6885b451636ae286c34628f70a7ed1fcc759f8d9ad382d132e1c8d3d9bfd/lxml-6.0.2-cp314-cp314-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:a4bf42d2e4cf52c28cc1812d62426b9503cdb0c87a6de81442626aa7d69707ba", size = 5352421, upload-time = "2025-09-22T04:02:40.413Z" },
-    { url = "https://files.pythonhosted.org/packages/48/5b/fc2ddfc94ddbe3eebb8e9af6e3fd65e2feba4967f6a4e9683875c394c2d8/lxml-6.0.2-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b2c7fdaa4d7c3d886a42534adec7cfac73860b89b4e5298752f60aa5984641a0", size = 5673684, upload-time = "2025-09-22T04:02:42.288Z" },
-    { url = "https://files.pythonhosted.org/packages/29/9c/47293c58cc91769130fbf85531280e8cc7868f7fbb6d92f4670071b9cb3e/lxml-6.0.2-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98a5e1660dc7de2200b00d53fa00bcd3c35a3608c305d45a7bbcaf29fa16e83d", size = 5252463, upload-time = "2025-09-22T04:02:44.165Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/da/ba6eceb830c762b48e711ded880d7e3e89fc6c7323e587c36540b6b23c6b/lxml-6.0.2-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:dc051506c30b609238d79eda75ee9cab3e520570ec8219844a72a46020901e37", size = 4698437, upload-time = "2025-09-22T04:02:46.524Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/24/7be3f82cb7990b89118d944b619e53c656c97dc89c28cfb143fdb7cd6f4d/lxml-6.0.2-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8799481bbdd212470d17513a54d568f44416db01250f49449647b5ab5b5dccb9", size = 5269890, upload-time = "2025-09-22T04:02:48.812Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/bd/dcfb9ea1e16c665efd7538fc5d5c34071276ce9220e234217682e7d2c4a5/lxml-6.0.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9261bb77c2dab42f3ecd9103951aeca2c40277701eb7e912c545c1b16e0e4917", size = 5097185, upload-time = "2025-09-22T04:02:50.746Z" },
-    { url = "https://files.pythonhosted.org/packages/21/04/a60b0ff9314736316f28316b694bccbbabe100f8483ad83852d77fc7468e/lxml-6.0.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:65ac4a01aba353cfa6d5725b95d7aed6356ddc0a3cd734de00124d285b04b64f", size = 4745895, upload-time = "2025-09-22T04:02:52.968Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/bd/7d54bd1846e5a310d9c715921c5faa71cf5c0853372adf78aee70c8d7aa2/lxml-6.0.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:b22a07cbb82fea98f8a2fd814f3d1811ff9ed76d0fc6abc84eb21527596e7cc8", size = 5695246, upload-time = "2025-09-22T04:02:54.798Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/32/5643d6ab947bc371da21323acb2a6e603cedbe71cb4c99c8254289ab6f4e/lxml-6.0.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:d759cdd7f3e055d6bc8d9bec3ad905227b2e4c785dc16c372eb5b5e83123f48a", size = 5260797, upload-time = "2025-09-22T04:02:57.058Z" },
-    { url = "https://files.pythonhosted.org/packages/33/da/34c1ec4cff1eea7d0b4cd44af8411806ed943141804ac9c5d565302afb78/lxml-6.0.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:945da35a48d193d27c188037a05fec5492937f66fb1958c24fc761fb9d40d43c", size = 5277404, upload-time = "2025-09-22T04:02:58.966Z" },
-    { url = "https://files.pythonhosted.org/packages/82/57/4eca3e31e54dc89e2c3507e1cd411074a17565fa5ffc437c4ae0a00d439e/lxml-6.0.2-cp314-cp314-win32.whl", hash = "sha256:be3aaa60da67e6153eb15715cc2e19091af5dc75faef8b8a585aea372507384b", size = 3670072, upload-time = "2025-09-22T04:03:38.05Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/e0/c96cf13eccd20c9421ba910304dae0f619724dcf1702864fd59dd386404d/lxml-6.0.2-cp314-cp314-win_amd64.whl", hash = "sha256:fa25afbadead523f7001caf0c2382afd272c315a033a7b06336da2637d92d6ed", size = 4080617, upload-time = "2025-09-22T04:03:39.835Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/5d/b3f03e22b3d38d6f188ef044900a9b29b2fe0aebb94625ce9fe244011d34/lxml-6.0.2-cp314-cp314-win_arm64.whl", hash = "sha256:063eccf89df5b24e361b123e257e437f9e9878f425ee9aae3144c77faf6da6d8", size = 3754930, upload-time = "2025-09-22T04:03:41.565Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/5c/42c2c4c03554580708fc738d13414801f340c04c3eff90d8d2d227145275/lxml-6.0.2-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:6162a86d86893d63084faaf4ff937b3daea233e3682fb4474db07395794fa80d", size = 8910380, upload-time = "2025-09-22T04:03:01.645Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/4f/12df843e3e10d18d468a7557058f8d3733e8b6e12401f30b1ef29360740f/lxml-6.0.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:414aaa94e974e23a3e92e7ca5b97d10c0cf37b6481f50911032c69eeb3991bba", size = 4775632, upload-time = "2025-09-22T04:03:03.814Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/0c/9dc31e6c2d0d418483cbcb469d1f5a582a1cd00a1f4081953d44051f3c50/lxml-6.0.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48461bd21625458dd01e14e2c38dd0aea69addc3c4f960c30d9f59d7f93be601", size = 4975171, upload-time = "2025-09-22T04:03:05.651Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/2b/9b870c6ca24c841bdd887504808f0417aa9d8d564114689266f19ddf29c8/lxml-6.0.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:25fcc59afc57d527cfc78a58f40ab4c9b8fd096a9a3f964d2781ffb6eb33f4ed", size = 5110109, upload-time = "2025-09-22T04:03:07.452Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/0c/4f5f2a4dd319a178912751564471355d9019e220c20d7db3fb8307ed8582/lxml-6.0.2-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5179c60288204e6ddde3f774a93350177e08876eaf3ab78aa3a3649d43eb7d37", size = 5041061, upload-time = "2025-09-22T04:03:09.297Z" },
-    { url = "https://files.pythonhosted.org/packages/12/64/554eed290365267671fe001a20d72d14f468ae4e6acef1e179b039436967/lxml-6.0.2-cp314-cp314t-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:967aab75434de148ec80597b75062d8123cadf2943fb4281f385141e18b21338", size = 5306233, upload-time = "2025-09-22T04:03:11.651Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/31/1d748aa275e71802ad9722df32a7a35034246b42c0ecdd8235412c3396ef/lxml-6.0.2-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d100fcc8930d697c6561156c6810ab4a508fb264c8b6779e6e61e2ed5e7558f9", size = 5604739, upload-time = "2025-09-22T04:03:13.592Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/41/2c11916bcac09ed561adccacceaedd2bf0e0b25b297ea92aab99fd03d0fa/lxml-6.0.2-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2ca59e7e13e5981175b8b3e4ab84d7da57993eeff53c07764dcebda0d0e64ecd", size = 5225119, upload-time = "2025-09-22T04:03:15.408Z" },
-    { url = "https://files.pythonhosted.org/packages/99/05/4e5c2873d8f17aa018e6afde417c80cc5d0c33be4854cce3ef5670c49367/lxml-6.0.2-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:957448ac63a42e2e49531b9d6c0fa449a1970dbc32467aaad46f11545be9af1d", size = 4633665, upload-time = "2025-09-22T04:03:17.262Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/c9/dcc2da1bebd6275cdc723b515f93edf548b82f36a5458cca3578bc899332/lxml-6.0.2-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b7fc49c37f1786284b12af63152fe1d0990722497e2d5817acfe7a877522f9a9", size = 5234997, upload-time = "2025-09-22T04:03:19.14Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/e2/5172e4e7468afca64a37b81dba152fc5d90e30f9c83c7c3213d6a02a5ce4/lxml-6.0.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e19e0643cc936a22e837f79d01a550678da8377d7d801a14487c10c34ee49c7e", size = 5090957, upload-time = "2025-09-22T04:03:21.436Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/b3/15461fd3e5cd4ddcb7938b87fc20b14ab113b92312fc97afe65cd7c85de1/lxml-6.0.2-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:1db01e5cf14345628e0cbe71067204db658e2fb8e51e7f33631f5f4735fefd8d", size = 4764372, upload-time = "2025-09-22T04:03:23.27Z" },
-    { url = "https://files.pythonhosted.org/packages/05/33/f310b987c8bf9e61c4dd8e8035c416bd3230098f5e3cfa69fc4232de7059/lxml-6.0.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:875c6b5ab39ad5291588aed6925fac99d0097af0dd62f33c7b43736043d4a2ec", size = 5634653, upload-time = "2025-09-22T04:03:25.767Z" },
-    { url = "https://files.pythonhosted.org/packages/70/ff/51c80e75e0bc9382158133bdcf4e339b5886c6ee2418b5199b3f1a61ed6d/lxml-6.0.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:cdcbed9ad19da81c480dfd6dd161886db6096083c9938ead313d94b30aadf272", size = 5233795, upload-time = "2025-09-22T04:03:27.62Z" },
-    { url = "https://files.pythonhosted.org/packages/56/4d/4856e897df0d588789dd844dbed9d91782c4ef0b327f96ce53c807e13128/lxml-6.0.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:80dadc234ebc532e09be1975ff538d154a7fa61ea5031c03d25178855544728f", size = 5257023, upload-time = "2025-09-22T04:03:30.056Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/85/86766dfebfa87bea0ab78e9ff7a4b4b45225df4b4d3b8cc3c03c5cd68464/lxml-6.0.2-cp314-cp314t-win32.whl", hash = "sha256:da08e7bb297b04e893d91087df19638dc7a6bb858a954b0cc2b9f5053c922312", size = 3911420, upload-time = "2025-09-22T04:03:32.198Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/1a/b248b355834c8e32614650b8008c69ffeb0ceb149c793961dd8c0b991bb3/lxml-6.0.2-cp314-cp314t-win_amd64.whl", hash = "sha256:252a22982dca42f6155125ac76d3432e548a7625d56f5a273ee78a5057216eca", size = 4406837, upload-time = "2025-09-22T04:03:34.027Z" },
-    { url = "https://files.pythonhosted.org/packages/92/aa/df863bcc39c5e0946263454aba394de8a9084dbaff8ad143846b0d844739/lxml-6.0.2-cp314-cp314t-win_arm64.whl", hash = "sha256:bb4c1847b303835d89d785a18801a883436cdfd5dc3d62947f9c49e24f0f5a2c", size = 3822205, upload-time = "2025-09-22T04:03:36.249Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/11/29d08bc103a62c0eba8016e7ed5aeebbf1e4312e83b0b1648dd203b0e87d/lxml-6.0.2-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:1c06035eafa8404b5cf475bb37a9f6088b0aca288d4ccc9d69389750d5543700", size = 3949829, upload-time = "2025-09-22T04:04:45.608Z" },
-    { url = "https://files.pythonhosted.org/packages/12/b3/52ab9a3b31e5ab8238da241baa19eec44d2ab426532441ee607165aebb52/lxml-6.0.2-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c7d13103045de1bdd6fe5d61802565f1a3537d70cd3abf596aa0af62761921ee", size = 4226277, upload-time = "2025-09-22T04:04:47.754Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/33/1eaf780c1baad88224611df13b1c2a9dfa460b526cacfe769103ff50d845/lxml-6.0.2-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0a3c150a95fbe5ac91de323aa756219ef9cf7fde5a3f00e2281e30f33fa5fa4f", size = 4330433, upload-time = "2025-09-22T04:04:49.907Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/c1/27428a2ff348e994ab4f8777d3a0ad510b6b92d37718e5887d2da99952a2/lxml-6.0.2-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60fa43be34f78bebb27812ed90f1925ec99560b0fa1decdb7d12b84d857d31e9", size = 4272119, upload-time = "2025-09-22T04:04:51.801Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/d0/3020fa12bcec4ab62f97aab026d57c2f0cfd480a558758d9ca233bb6a79d/lxml-6.0.2-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:21c73b476d3cfe836be731225ec3421fa2f048d84f6df6a8e70433dff1376d5a", size = 4417314, upload-time = "2025-09-22T04:04:55.024Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/77/d7f491cbc05303ac6801651aabeb262d43f319288c1ea96c66b1d2692ff3/lxml-6.0.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:27220da5be049e936c3aca06f174e8827ca6445a4353a1995584311487fc4e3e", size = 3518768, upload-time = "2025-09-22T04:04:57.097Z" },
-]
-
-[[package]]
 name = "markdown-it-py"
-version = "4.0.0"
+version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mdurl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
 ]
 
 [[package]]
@@ -347,11 +196,30 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "25.0"
+version = "26.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "patchright"
+version = "1.59.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/1d/e6a4b7ff95c35617495a9b686cbf78a968f26ad51c91cef6b2a5eee88f3e/patchright-1.59.1-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:de2e0ea51a270e77ef6588bea1370510695cb94fe6ef848bc7e587d3458764ea", size = 43143713, upload-time = "2026-04-29T08:02:46.651Z" },
+    { url = "https://files.pythonhosted.org/packages/de/55/0b4bb56c141f2906e212c5b31f21ba6107a98105240c173b54d72c74f480/patchright-1.59.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e93fe960714c39152ea3300b7a2c3882cb8d1f992f6120db53406b5590fa4208", size = 41933976, upload-time = "2026-04-29T08:02:51.531Z" },
+    { url = "https://files.pythonhosted.org/packages/72/fc/98ad4f09613051b8c673701043ba6744a213175b01399e555b73de742006/patchright-1.59.1-py3-none-macosx_11_0_universal2.whl", hash = "sha256:bfaad3600817f271ccab34db9f33bb8148c649a157bad28b727097d0b45b8c5d", size = 43143717, upload-time = "2026-04-29T08:02:55.619Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/cc/f62063e59db98b154d9faf79603164d548f5117c95acc9d2a8104df9607a/patchright-1.59.1-py3-none-manylinux1_x86_64.whl", hash = "sha256:f0a7ee31e56391a96cd81f9ac1db130e8166c6083b7f3fb3bc9ba19d80d68127", size = 47138586, upload-time = "2026-04-29T08:03:00.04Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/74/2965635dd1d461243281e1774f78d865c2d1df24808cbe3b27a5ede64d7e/patchright-1.59.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69165d20308a045ddf1ad512467625248c5763ea9ee36ee57b0003d1ff8b9b12", size = 46864405, upload-time = "2026-04-29T08:03:04.825Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c2/959acc3fd3d867af4e567bb5e0cc63d4b1ca17fe4b7f673b3eef52fbf287/patchright-1.59.1-py3-none-win32.whl", hash = "sha256:56d9f2f3325f7205dfe6d22abc0969378225cd58b6ce29e7a7e3526c1d78c160", size = 37700491, upload-time = "2026-04-29T08:03:09.81Z" },
+    { url = "https://files.pythonhosted.org/packages/19/b1/1e7a4844ed6bc6bd3653c6e708f614a2b27ac54875ebd0e9c7badf7d25b6/patchright-1.59.1-py3-none-win_amd64.whl", hash = "sha256:3af6515b6103aedd1cdd09be7fa08ac028a954c6687d73fdee92570ae580fe4c", size = 37700495, upload-time = "2026-04-29T08:03:13.727Z" },
+    { url = "https://files.pythonhosted.org/packages/10/95/b148a41c6a099cd3d9f11a0641e4f10d50141cb8dca052f75f64dc631634/patchright-1.59.1-py3-none-win_arm64.whl", hash = "sha256:e259fae74b59a89ee020703ba142b8b5dd81a08f1c95ee3cda92829026057092", size = 33943539, upload-time = "2026-04-29T08:03:17.355Z" },
 ]
 
 [[package]]
@@ -364,134 +232,29 @@ wheels = [
 ]
 
 [[package]]
-name = "pydantic"
-version = "2.12.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "annotated-types" },
-    { name = "pydantic-core" },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/1e/4f0a3233767010308f2fd6bd0814597e3f63f1dc98304a9112b8759df4ff/pydantic-2.12.3.tar.gz", hash = "sha256:1da1c82b0fc140bb0103bc1441ffe062154c8d38491189751ee00fd8ca65ce74", size = 819383, upload-time = "2025-10-17T15:04:21.222Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/6b/83661fa77dcefa195ad5f8cd9af3d1a7450fd57cc883ad04d65446ac2029/pydantic-2.12.3-py3-none-any.whl", hash = "sha256:6986454a854bc3bc6e5443e1369e06a3a456af9d339eda45510f517d9ea5c6bf", size = 462431, upload-time = "2025-10-17T15:04:19.346Z" },
-]
-
-[[package]]
-name = "pydantic-core"
-version = "2.41.4"
+name = "pyee"
+version = "13.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/18/d0944e8eaaa3efd0a91b0f1fc537d3be55ad35091b6a87638211ba691964/pydantic_core-2.41.4.tar.gz", hash = "sha256:70e47929a9d4a1905a67e4b687d5946026390568a8e952b92824118063cee4d5", size = 457557, upload-time = "2025-10-14T10:23:47.909Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/4c/f6cbfa1e8efacd00b846764e8484fe173d25b8dab881e277a619177f3384/pydantic_core-2.41.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:28ff11666443a1a8cf2a044d6a545ebffa8382b5f7973f22c36109205e65dc80", size = 2109062, upload-time = "2025-10-14T10:20:04.486Z" },
-    { url = "https://files.pythonhosted.org/packages/21/f8/40b72d3868896bfcd410e1bd7e516e762d326201c48e5b4a06446f6cf9e8/pydantic_core-2.41.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:61760c3925d4633290292bad462e0f737b840508b4f722247d8729684f6539ae", size = 1916301, upload-time = "2025-10-14T10:20:06.857Z" },
-    { url = "https://files.pythonhosted.org/packages/94/4d/d203dce8bee7faeca791671c88519969d98d3b4e8f225da5b96dad226fc8/pydantic_core-2.41.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eae547b7315d055b0de2ec3965643b0ab82ad0106a7ffd29615ee9f266a02827", size = 1968728, upload-time = "2025-10-14T10:20:08.353Z" },
-    { url = "https://files.pythonhosted.org/packages/65/f5/6a66187775df87c24d526985b3a5d78d861580ca466fbd9d4d0e792fcf6c/pydantic_core-2.41.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ef9ee5471edd58d1fcce1c80ffc8783a650e3e3a193fe90d52e43bb4d87bff1f", size = 2050238, upload-time = "2025-10-14T10:20:09.766Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/b9/78336345de97298cf53236b2f271912ce11f32c1e59de25a374ce12f9cce/pydantic_core-2.41.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:15dd504af121caaf2c95cb90c0ebf71603c53de98305621b94da0f967e572def", size = 2249424, upload-time = "2025-10-14T10:20:11.732Z" },
-    { url = "https://files.pythonhosted.org/packages/99/bb/a4584888b70ee594c3d374a71af5075a68654d6c780369df269118af7402/pydantic_core-2.41.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a926768ea49a8af4d36abd6a8968b8790f7f76dd7cbd5a4c180db2b4ac9a3a2", size = 2366047, upload-time = "2025-10-14T10:20:13.647Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/8d/17fc5de9d6418e4d2ae8c675f905cdafdc59d3bf3bf9c946b7ab796a992a/pydantic_core-2.41.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6916b9b7d134bff5440098a4deb80e4cb623e68974a87883299de9124126c2a8", size = 2071163, upload-time = "2025-10-14T10:20:15.307Z" },
-    { url = "https://files.pythonhosted.org/packages/54/e7/03d2c5c0b8ed37a4617430db68ec5e7dbba66358b629cd69e11b4d564367/pydantic_core-2.41.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5cf90535979089df02e6f17ffd076f07237efa55b7343d98760bde8743c4b265", size = 2190585, upload-time = "2025-10-14T10:20:17.3Z" },
-    { url = "https://files.pythonhosted.org/packages/be/fc/15d1c9fe5ad9266a5897d9b932b7f53d7e5cfc800573917a2c5d6eea56ec/pydantic_core-2.41.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:7533c76fa647fade2d7ec75ac5cc079ab3f34879626dae5689b27790a6cf5a5c", size = 2150109, upload-time = "2025-10-14T10:20:19.143Z" },
-    { url = "https://files.pythonhosted.org/packages/26/ef/e735dd008808226c83ba56972566138665b71477ad580fa5a21f0851df48/pydantic_core-2.41.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:37e516bca9264cbf29612539801ca3cd5d1be465f940417b002905e6ed79d38a", size = 2315078, upload-time = "2025-10-14T10:20:20.742Z" },
-    { url = "https://files.pythonhosted.org/packages/90/00/806efdcf35ff2ac0f938362350cd9827b8afb116cc814b6b75cf23738c7c/pydantic_core-2.41.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:0c19cb355224037c83642429b8ce261ae108e1c5fbf5c028bac63c77b0f8646e", size = 2318737, upload-time = "2025-10-14T10:20:22.306Z" },
-    { url = "https://files.pythonhosted.org/packages/41/7e/6ac90673fe6cb36621a2283552897838c020db343fa86e513d3f563b196f/pydantic_core-2.41.4-cp311-cp311-win32.whl", hash = "sha256:09c2a60e55b357284b5f31f5ab275ba9f7f70b7525e18a132ec1f9160b4f1f03", size = 1974160, upload-time = "2025-10-14T10:20:23.817Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/9d/7c5e24ee585c1f8b6356e1d11d40ab807ffde44d2db3b7dfd6d20b09720e/pydantic_core-2.41.4-cp311-cp311-win_amd64.whl", hash = "sha256:711156b6afb5cb1cb7c14a2cc2c4a8b4c717b69046f13c6b332d8a0a8f41ca3e", size = 2021883, upload-time = "2025-10-14T10:20:25.48Z" },
-    { url = "https://files.pythonhosted.org/packages/33/90/5c172357460fc28b2871eb4a0fb3843b136b429c6fa827e4b588877bf115/pydantic_core-2.41.4-cp311-cp311-win_arm64.whl", hash = "sha256:6cb9cf7e761f4f8a8589a45e49ed3c0d92d1d696a45a6feaee8c904b26efc2db", size = 1968026, upload-time = "2025-10-14T10:20:27.039Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/81/d3b3e95929c4369d30b2a66a91db63c8ed0a98381ae55a45da2cd1cc1288/pydantic_core-2.41.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:ab06d77e053d660a6faaf04894446df7b0a7e7aba70c2797465a0a1af00fc887", size = 2099043, upload-time = "2025-10-14T10:20:28.561Z" },
-    { url = "https://files.pythonhosted.org/packages/58/da/46fdac49e6717e3a94fc9201403e08d9d61aa7a770fab6190b8740749047/pydantic_core-2.41.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c53ff33e603a9c1179a9364b0a24694f183717b2e0da2b5ad43c316c956901b2", size = 1910699, upload-time = "2025-10-14T10:20:30.217Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/63/4d948f1b9dd8e991a5a98b77dd66c74641f5f2e5225fee37994b2e07d391/pydantic_core-2.41.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:304c54176af2c143bd181d82e77c15c41cbacea8872a2225dd37e6544dce9999", size = 1952121, upload-time = "2025-10-14T10:20:32.246Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/a7/e5fc60a6f781fc634ecaa9ecc3c20171d238794cef69ae0af79ac11b89d7/pydantic_core-2.41.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:025ba34a4cf4fb32f917d5d188ab5e702223d3ba603be4d8aca2f82bede432a4", size = 2041590, upload-time = "2025-10-14T10:20:34.332Z" },
-    { url = "https://files.pythonhosted.org/packages/70/69/dce747b1d21d59e85af433428978a1893c6f8a7068fa2bb4a927fba7a5ff/pydantic_core-2.41.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b9f5f30c402ed58f90c70e12eff65547d3ab74685ffe8283c719e6bead8ef53f", size = 2219869, upload-time = "2025-10-14T10:20:35.965Z" },
-    { url = "https://files.pythonhosted.org/packages/83/6a/c070e30e295403bf29c4df1cb781317b6a9bac7cd07b8d3acc94d501a63c/pydantic_core-2.41.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dd96e5d15385d301733113bcaa324c8bcf111275b7675a9c6e88bfb19fc05e3b", size = 2345169, upload-time = "2025-10-14T10:20:37.627Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/83/06d001f8043c336baea7fd202a9ac7ad71f87e1c55d8112c50b745c40324/pydantic_core-2.41.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98f348cbb44fae6e9653c1055db7e29de67ea6a9ca03a5fa2c2e11a47cff0e47", size = 2070165, upload-time = "2025-10-14T10:20:39.246Z" },
-    { url = "https://files.pythonhosted.org/packages/14/0a/e567c2883588dd12bcbc110232d892cf385356f7c8a9910311ac997ab715/pydantic_core-2.41.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ec22626a2d14620a83ca583c6f5a4080fa3155282718b6055c2ea48d3ef35970", size = 2189067, upload-time = "2025-10-14T10:20:41.015Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/1d/3d9fca34273ba03c9b1c5289f7618bc4bd09c3ad2289b5420481aa051a99/pydantic_core-2.41.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:3a95d4590b1f1a43bf33ca6d647b990a88f4a3824a8c4572c708f0b45a5290ed", size = 2132997, upload-time = "2025-10-14T10:20:43.106Z" },
-    { url = "https://files.pythonhosted.org/packages/52/70/d702ef7a6cd41a8afc61f3554922b3ed8d19dd54c3bd4bdbfe332e610827/pydantic_core-2.41.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:f9672ab4d398e1b602feadcffcdd3af44d5f5e6ddc15bc7d15d376d47e8e19f8", size = 2307187, upload-time = "2025-10-14T10:20:44.849Z" },
-    { url = "https://files.pythonhosted.org/packages/68/4c/c06be6e27545d08b802127914156f38d10ca287a9e8489342793de8aae3c/pydantic_core-2.41.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:84d8854db5f55fead3b579f04bda9a36461dab0730c5d570e1526483e7bb8431", size = 2305204, upload-time = "2025-10-14T10:20:46.781Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/e5/35ae4919bcd9f18603419e23c5eaf32750224a89d41a8df1a3704b69f77e/pydantic_core-2.41.4-cp312-cp312-win32.whl", hash = "sha256:9be1c01adb2ecc4e464392c36d17f97e9110fbbc906bcbe1c943b5b87a74aabd", size = 1972536, upload-time = "2025-10-14T10:20:48.39Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/c2/49c5bb6d2a49eb2ee3647a93e3dae7080c6409a8a7558b075027644e879c/pydantic_core-2.41.4-cp312-cp312-win_amd64.whl", hash = "sha256:d682cf1d22bab22a5be08539dca3d1593488a99998f9f412137bc323179067ff", size = 2031132, upload-time = "2025-10-14T10:20:50.421Z" },
-    { url = "https://files.pythonhosted.org/packages/06/23/936343dbcba6eec93f73e95eb346810fc732f71ba27967b287b66f7b7097/pydantic_core-2.41.4-cp312-cp312-win_arm64.whl", hash = "sha256:833eebfd75a26d17470b58768c1834dfc90141b7afc6eb0429c21fc5a21dcfb8", size = 1969483, upload-time = "2025-10-14T10:20:52.35Z" },
-    { url = "https://files.pythonhosted.org/packages/13/d0/c20adabd181a029a970738dfe23710b52a31f1258f591874fcdec7359845/pydantic_core-2.41.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:85e050ad9e5f6fe1004eec65c914332e52f429bc0ae12d6fa2092407a462c746", size = 2105688, upload-time = "2025-10-14T10:20:54.448Z" },
-    { url = "https://files.pythonhosted.org/packages/00/b6/0ce5c03cec5ae94cca220dfecddc453c077d71363b98a4bbdb3c0b22c783/pydantic_core-2.41.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7393f1d64792763a48924ba31d1e44c2cfbc05e3b1c2c9abb4ceeadd912cced", size = 1910807, upload-time = "2025-10-14T10:20:56.115Z" },
-    { url = "https://files.pythonhosted.org/packages/68/3e/800d3d02c8beb0b5c069c870cbb83799d085debf43499c897bb4b4aaff0d/pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94dab0940b0d1fb28bcab847adf887c66a27a40291eedf0b473be58761c9799a", size = 1956669, upload-time = "2025-10-14T10:20:57.874Z" },
-    { url = "https://files.pythonhosted.org/packages/60/a4/24271cc71a17f64589be49ab8bd0751f6a0a03046c690df60989f2f95c2c/pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:de7c42f897e689ee6f9e93c4bec72b99ae3b32a2ade1c7e4798e690ff5246e02", size = 2051629, upload-time = "2025-10-14T10:21:00.006Z" },
-    { url = "https://files.pythonhosted.org/packages/68/de/45af3ca2f175d91b96bfb62e1f2d2f1f9f3b14a734afe0bfeff079f78181/pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:664b3199193262277b8b3cd1e754fb07f2c6023289c815a1e1e8fb415cb247b1", size = 2224049, upload-time = "2025-10-14T10:21:01.801Z" },
-    { url = "https://files.pythonhosted.org/packages/af/8f/ae4e1ff84672bf869d0a77af24fd78387850e9497753c432875066b5d622/pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d95b253b88f7d308b1c0b417c4624f44553ba4762816f94e6986819b9c273fb2", size = 2342409, upload-time = "2025-10-14T10:21:03.556Z" },
-    { url = "https://files.pythonhosted.org/packages/18/62/273dd70b0026a085c7b74b000394e1ef95719ea579c76ea2f0cc8893736d/pydantic_core-2.41.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a1351f5bbdbbabc689727cb91649a00cb9ee7203e0a6e54e9f5ba9e22e384b84", size = 2069635, upload-time = "2025-10-14T10:21:05.385Z" },
-    { url = "https://files.pythonhosted.org/packages/30/03/cf485fff699b4cdaea469bc481719d3e49f023241b4abb656f8d422189fc/pydantic_core-2.41.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1affa4798520b148d7182da0615d648e752de4ab1a9566b7471bc803d88a062d", size = 2194284, upload-time = "2025-10-14T10:21:07.122Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/7e/c8e713db32405dfd97211f2fc0a15d6bf8adb7640f3d18544c1f39526619/pydantic_core-2.41.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7b74e18052fea4aa8dea2fb7dbc23d15439695da6cbe6cfc1b694af1115df09d", size = 2137566, upload-time = "2025-10-14T10:21:08.981Z" },
-    { url = "https://files.pythonhosted.org/packages/04/f7/db71fd4cdccc8b75990f79ccafbbd66757e19f6d5ee724a6252414483fb4/pydantic_core-2.41.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:285b643d75c0e30abda9dc1077395624f314a37e3c09ca402d4015ef5979f1a2", size = 2316809, upload-time = "2025-10-14T10:21:10.805Z" },
-    { url = "https://files.pythonhosted.org/packages/76/63/a54973ddb945f1bca56742b48b144d85c9fc22f819ddeb9f861c249d5464/pydantic_core-2.41.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:f52679ff4218d713b3b33f88c89ccbf3a5c2c12ba665fb80ccc4192b4608dbab", size = 2311119, upload-time = "2025-10-14T10:21:12.583Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/03/5d12891e93c19218af74843a27e32b94922195ded2386f7b55382f904d2f/pydantic_core-2.41.4-cp313-cp313-win32.whl", hash = "sha256:ecde6dedd6fff127c273c76821bb754d793be1024bc33314a120f83a3c69460c", size = 1981398, upload-time = "2025-10-14T10:21:14.584Z" },
-    { url = "https://files.pythonhosted.org/packages/be/d8/fd0de71f39db91135b7a26996160de71c073d8635edfce8b3c3681be0d6d/pydantic_core-2.41.4-cp313-cp313-win_amd64.whl", hash = "sha256:d081a1f3800f05409ed868ebb2d74ac39dd0c1ff6c035b5162356d76030736d4", size = 2030735, upload-time = "2025-10-14T10:21:16.432Z" },
-    { url = "https://files.pythonhosted.org/packages/72/86/c99921c1cf6650023c08bfab6fe2d7057a5142628ef7ccfa9921f2dda1d5/pydantic_core-2.41.4-cp313-cp313-win_arm64.whl", hash = "sha256:f8e49c9c364a7edcbe2a310f12733aad95b022495ef2a8d653f645e5d20c1564", size = 1973209, upload-time = "2025-10-14T10:21:18.213Z" },
-    { url = "https://files.pythonhosted.org/packages/36/0d/b5706cacb70a8414396efdda3d72ae0542e050b591119e458e2490baf035/pydantic_core-2.41.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ed97fd56a561f5eb5706cebe94f1ad7c13b84d98312a05546f2ad036bafe87f4", size = 1877324, upload-time = "2025-10-14T10:21:20.363Z" },
-    { url = "https://files.pythonhosted.org/packages/de/2d/cba1fa02cfdea72dfb3a9babb067c83b9dff0bbcb198368e000a6b756ea7/pydantic_core-2.41.4-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a870c307bf1ee91fc58a9a61338ff780d01bfae45922624816878dce784095d2", size = 1884515, upload-time = "2025-10-14T10:21:22.339Z" },
-    { url = "https://files.pythonhosted.org/packages/07/ea/3df927c4384ed9b503c9cc2d076cf983b4f2adb0c754578dfb1245c51e46/pydantic_core-2.41.4-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d25e97bc1f5f8f7985bdc2335ef9e73843bb561eb1fa6831fdfc295c1c2061cf", size = 2042819, upload-time = "2025-10-14T10:21:26.683Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/ee/df8e871f07074250270a3b1b82aad4cd0026b588acd5d7d3eb2fcb1471a3/pydantic_core-2.41.4-cp313-cp313t-win_amd64.whl", hash = "sha256:d405d14bea042f166512add3091c1af40437c2e7f86988f3915fabd27b1e9cd2", size = 1995866, upload-time = "2025-10-14T10:21:28.951Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/de/b20f4ab954d6d399499c33ec4fafc46d9551e11dc1858fb7f5dca0748ceb/pydantic_core-2.41.4-cp313-cp313t-win_arm64.whl", hash = "sha256:19f3684868309db5263a11bace3c45d93f6f24afa2ffe75a647583df22a2ff89", size = 1970034, upload-time = "2025-10-14T10:21:30.869Z" },
-    { url = "https://files.pythonhosted.org/packages/54/28/d3325da57d413b9819365546eb9a6e8b7cbd9373d9380efd5f74326143e6/pydantic_core-2.41.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:e9205d97ed08a82ebb9a307e92914bb30e18cdf6f6b12ca4bedadb1588a0bfe1", size = 2102022, upload-time = "2025-10-14T10:21:32.809Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/24/b58a1bc0d834bf1acc4361e61233ee217169a42efbdc15a60296e13ce438/pydantic_core-2.41.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:82df1f432b37d832709fbcc0e24394bba04a01b6ecf1ee87578145c19cde12ac", size = 1905495, upload-time = "2025-10-14T10:21:34.812Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/a4/71f759cc41b7043e8ecdaab81b985a9b6cad7cec077e0b92cff8b71ecf6b/pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc3b4cc4539e055cfa39a3763c939f9d409eb40e85813257dcd761985a108554", size = 1956131, upload-time = "2025-10-14T10:21:36.924Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/64/1e79ac7aa51f1eec7c4cda8cbe456d5d09f05fdd68b32776d72168d54275/pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b1eb1754fce47c63d2ff57fdb88c351a6c0150995890088b33767a10218eaa4e", size = 2052236, upload-time = "2025-10-14T10:21:38.927Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/e3/a3ffc363bd4287b80f1d43dc1c28ba64831f8dfc237d6fec8f2661138d48/pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e6ab5ab30ef325b443f379ddb575a34969c333004fca5a1daa0133a6ffaad616", size = 2223573, upload-time = "2025-10-14T10:21:41.574Z" },
-    { url = "https://files.pythonhosted.org/packages/28/27/78814089b4d2e684a9088ede3790763c64693c3d1408ddc0a248bc789126/pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:31a41030b1d9ca497634092b46481b937ff9397a86f9f51bd41c4767b6fc04af", size = 2342467, upload-time = "2025-10-14T10:21:44.018Z" },
-    { url = "https://files.pythonhosted.org/packages/92/97/4de0e2a1159cb85ad737e03306717637842c88c7fd6d97973172fb183149/pydantic_core-2.41.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a44ac1738591472c3d020f61c6df1e4015180d6262ebd39bf2aeb52571b60f12", size = 2063754, upload-time = "2025-10-14T10:21:46.466Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/50/8cb90ce4b9efcf7ae78130afeb99fd1c86125ccdf9906ef64b9d42f37c25/pydantic_core-2.41.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d72f2b5e6e82ab8f94ea7d0d42f83c487dc159c5240d8f83beae684472864e2d", size = 2196754, upload-time = "2025-10-14T10:21:48.486Z" },
-    { url = "https://files.pythonhosted.org/packages/34/3b/ccdc77af9cd5082723574a1cc1bcae7a6acacc829d7c0a06201f7886a109/pydantic_core-2.41.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:c4d1e854aaf044487d31143f541f7aafe7b482ae72a022c664b2de2e466ed0ad", size = 2137115, upload-time = "2025-10-14T10:21:50.63Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/ba/e7c7a02651a8f7c52dc2cff2b64a30c313e3b57c7d93703cecea76c09b71/pydantic_core-2.41.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b568af94267729d76e6ee5ececda4e283d07bbb28e8148bb17adad93d025d25a", size = 2317400, upload-time = "2025-10-14T10:21:52.959Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/ba/6c533a4ee8aec6b812c643c49bb3bd88d3f01e3cebe451bb85512d37f00f/pydantic_core-2.41.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:6d55fb8b1e8929b341cc313a81a26e0d48aa3b519c1dbaadec3a6a2b4fcad025", size = 2312070, upload-time = "2025-10-14T10:21:55.419Z" },
-    { url = "https://files.pythonhosted.org/packages/22/ae/f10524fcc0ab8d7f96cf9a74c880243576fd3e72bd8ce4f81e43d22bcab7/pydantic_core-2.41.4-cp314-cp314-win32.whl", hash = "sha256:5b66584e549e2e32a1398df11da2e0a7eff45d5c2d9db9d5667c5e6ac764d77e", size = 1982277, upload-time = "2025-10-14T10:21:57.474Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/dc/e5aa27aea1ad4638f0c3fb41132f7eb583bd7420ee63204e2d4333a3bbf9/pydantic_core-2.41.4-cp314-cp314-win_amd64.whl", hash = "sha256:557a0aab88664cc552285316809cab897716a372afaf8efdbef756f8b890e894", size = 2024608, upload-time = "2025-10-14T10:21:59.557Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/61/51d89cc2612bd147198e120a13f150afbf0bcb4615cddb049ab10b81b79e/pydantic_core-2.41.4-cp314-cp314-win_arm64.whl", hash = "sha256:3f1ea6f48a045745d0d9f325989d8abd3f1eaf47dd00485912d1a3a63c623a8d", size = 1967614, upload-time = "2025-10-14T10:22:01.847Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/c2/472f2e31b95eff099961fa050c376ab7156a81da194f9edb9f710f68787b/pydantic_core-2.41.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6c1fe4c5404c448b13188dd8bd2ebc2bdd7e6727fa61ff481bcc2cca894018da", size = 1876904, upload-time = "2025-10-14T10:22:04.062Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/07/ea8eeb91173807ecdae4f4a5f4b150a520085b35454350fc219ba79e66a3/pydantic_core-2.41.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:523e7da4d43b113bf8e7b49fa4ec0c35bf4fe66b2230bfc5c13cc498f12c6c3e", size = 1882538, upload-time = "2025-10-14T10:22:06.39Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/29/b53a9ca6cd366bfc928823679c6a76c7a4c69f8201c0ba7903ad18ebae2f/pydantic_core-2.41.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5729225de81fb65b70fdb1907fcf08c75d498f4a6f15af005aabb1fdadc19dfa", size = 2041183, upload-time = "2025-10-14T10:22:08.812Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/3d/f8c1a371ceebcaf94d6dd2d77c6cf4b1c078e13a5837aee83f760b4f7cfd/pydantic_core-2.41.4-cp314-cp314t-win_amd64.whl", hash = "sha256:de2cfbb09e88f0f795fd90cf955858fc2c691df65b1f21f0aa00b99f3fbc661d", size = 1993542, upload-time = "2025-10-14T10:22:11.332Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/ac/9fc61b4f9d079482a290afe8d206b8f490e9fd32d4fc03ed4fc698214e01/pydantic_core-2.41.4-cp314-cp314t-win_arm64.whl", hash = "sha256:d34f950ae05a83e0ede899c595f312ca976023ea1db100cd5aa188f7005e3ab0", size = 1973897, upload-time = "2025-10-14T10:22:13.444Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/12/5ba58daa7f453454464f92b3ca7b9d7c657d8641c48e370c3ebc9a82dd78/pydantic_core-2.41.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:a1b2cfec3879afb742a7b0bcfa53e4f22ba96571c9e54d6a3afe1052d17d843b", size = 2122139, upload-time = "2025-10-14T10:22:47.288Z" },
-    { url = "https://files.pythonhosted.org/packages/21/fb/6860126a77725c3108baecd10fd3d75fec25191d6381b6eb2ac660228eac/pydantic_core-2.41.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:d175600d975b7c244af6eb9c9041f10059f20b8bbffec9e33fdd5ee3f67cdc42", size = 1936674, upload-time = "2025-10-14T10:22:49.555Z" },
-    { url = "https://files.pythonhosted.org/packages/de/be/57dcaa3ed595d81f8757e2b44a38240ac5d37628bce25fb20d02c7018776/pydantic_core-2.41.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0f184d657fa4947ae5ec9c47bd7e917730fa1cbb78195037e32dcbab50aca5ee", size = 1956398, upload-time = "2025-10-14T10:22:52.19Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/1d/679a344fadb9695f1a6a294d739fbd21d71fa023286daeea8c0ed49e7c2b/pydantic_core-2.41.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ed810568aeffed3edc78910af32af911c835cc39ebbfacd1f0ab5dd53028e5c", size = 2138674, upload-time = "2025-10-14T10:22:54.499Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/48/ae937e5a831b7c0dc646b2ef788c27cd003894882415300ed21927c21efa/pydantic_core-2.41.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:4f5d640aeebb438517150fdeec097739614421900e4a08db4a3ef38898798537", size = 2112087, upload-time = "2025-10-14T10:22:56.818Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/db/6db8073e3d32dae017da7e0d16a9ecb897d0a4d92e00634916e486097961/pydantic_core-2.41.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:4a9ab037b71927babc6d9e7fc01aea9e66dc2a4a34dff06ef0724a4049629f94", size = 1920387, upload-time = "2025-10-14T10:22:59.342Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/c1/dd3542d072fcc336030d66834872f0328727e3b8de289c662faa04aa270e/pydantic_core-2.41.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e4dab9484ec605c3016df9ad4fd4f9a390bc5d816a3b10c6550f8424bb80b18c", size = 1951495, upload-time = "2025-10-14T10:23:02.089Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/c6/db8d13a1f8ab3f1eb08c88bd00fd62d44311e3456d1e85c0e59e0a0376e7/pydantic_core-2.41.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd8a5028425820731d8c6c098ab642d7b8b999758e24acae03ed38a66eca8335", size = 2139008, upload-time = "2025-10-14T10:23:04.539Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/7d/138e902ed6399b866f7cfe4435d22445e16fff888a1c00560d9dc79a780f/pydantic_core-2.41.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:491535d45cd7ad7e4a2af4a5169b0d07bebf1adfd164b0368da8aa41e19907a5", size = 2104721, upload-time = "2025-10-14T10:23:26.906Z" },
-    { url = "https://files.pythonhosted.org/packages/47/13/0525623cf94627f7b53b4c2034c81edc8491cbfc7c28d5447fa318791479/pydantic_core-2.41.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:54d86c0cada6aba4ec4c047d0e348cbad7063b87ae0f005d9f8c9ad04d4a92a2", size = 1931608, upload-time = "2025-10-14T10:23:29.306Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/f9/744bc98137d6ef0a233f808bfc9b18cf94624bf30836a18d3b05d08bf418/pydantic_core-2.41.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eca1124aced216b2500dc2609eade086d718e8249cb9696660ab447d50a758bd", size = 2132986, upload-time = "2025-10-14T10:23:32.057Z" },
-    { url = "https://files.pythonhosted.org/packages/17/c8/629e88920171173f6049386cc71f893dff03209a9ef32b4d2f7e7c264bcf/pydantic_core-2.41.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6c9024169becccf0cb470ada03ee578d7348c119a0d42af3dcf9eda96e3a247c", size = 2187516, upload-time = "2025-10-14T10:23:34.871Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/0f/4f2734688d98488782218ca61bcc118329bf5de05bb7fe3adc7dd79b0b86/pydantic_core-2.41.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:26895a4268ae5a2849269f4991cdc97236e4b9c010e51137becf25182daac405", size = 2146146, upload-time = "2025-10-14T10:23:37.342Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/f2/ab385dbd94a052c62224b99cf99002eee99dbec40e10006c78575aead256/pydantic_core-2.41.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:ca4df25762cf71308c446e33c9b1fdca2923a3f13de616e2a949f38bf21ff5a8", size = 2311296, upload-time = "2025-10-14T10:23:40.145Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/8e/e4f12afe1beeb9823bba5375f8f258df0cc61b056b0195fb1cf9f62a1a58/pydantic_core-2.41.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:5a28fcedd762349519276c36634e71853b4541079cab4acaaac60c4421827308", size = 2315386, upload-time = "2025-10-14T10:23:42.624Z" },
-    { url = "https://files.pythonhosted.org/packages/48/f7/925f65d930802e3ea2eb4d5afa4cb8730c8dc0d2cb89a59dc4ed2fcb2d74/pydantic_core-2.41.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c173ddcd86afd2535e2b695217e82191580663a1d1928239f877f5a1649ef39f", size = 2147775, upload-time = "2025-10-14T10:23:45.406Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
-]
-
-[[package]]
-name = "pyparsing"
-version = "3.2.5"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f2/a5/181488fc2b9d093e3972d2a472855aae8a03f000592dbfce716a512b3359/pyparsing-3.2.5.tar.gz", hash = "sha256:2df8d5b7b2802ef88e8d016a2eb9c7aeaa923529cd251ed0fe4608275d4105b6", size = 1099274, upload-time = "2025-09-21T04:11:06.277Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/5e/1aa9a93198c6b64513c9d7752de7422c06402de6600a8767da1524f9570b/pyparsing-3.2.5-py3-none-any.whl", hash = "sha256:e38a4f02064cf41fe6593d328d0512495ad1f3d8a91c4f73fc401b3079a59a5e", size = 113890, upload-time = "2025-09-21T04:11:04.117Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -500,49 +263,22 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
-]
-
-[[package]]
-name = "requests"
-version = "2.32.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "charset-normalizer" },
-    { name = "idna" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
-]
-
-[[package]]
-name = "requests-toolbelt"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
 name = "rich"
-version = "14.2.0"
+version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/d2/8920e102050a0de7bfabeb4c4614a49248cf8d5d7a8d01885fbb24dc767a/rich-14.2.0.tar.gz", hash = "sha256:73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4", size = 219990, upload-time = "2025-10-09T14:16:53.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl", hash = "sha256:76bc51fe2e57d2b1be1f96c524b890b816e334ab4c1e45888799bfaab0021edd", size = 243393, upload-time = "2025-10-09T14:16:51.245Z" },
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
 ]
 
 [[package]]
@@ -551,46 +287,28 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "astral" },
-    { name = "beautifulsoup4" },
     { name = "click" },
-    { name = "cloudscraper" },
     { name = "httpx" },
-    { name = "lxml" },
-    { name = "pydantic" },
-    { name = "pytest" },
+    { name = "patchright" },
     { name = "rich" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "astral", specifier = ">=3.2" },
-    { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "click", specifier = ">=8.1.0" },
-    { name = "cloudscraper", specifier = ">=1.2.71" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "lxml", specifier = ">=5.0.0" },
-    { name = "pydantic", specifier = ">=2.0.0" },
-    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "patchright", specifier = ">=1.49.0" },
     { name = "rich", specifier = ">=13.0.0" },
 ]
 
-[[package]]
-name = "sniffio"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
-]
-
-[[package]]
-name = "soupsieve"
-version = "2.8"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6d/e6/21ccce3262dd4889aa3332e5a119a3491a95e8f60939870a3a035aabac0d/soupsieve-2.8.tar.gz", hash = "sha256:e2dd4a40a628cb5f28f6d4b0db8800b8f581b65bb380b97de22ba5ca8d72572f", size = 103472, upload-time = "2025-08-27T15:39:51.78Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl", hash = "sha256:0cc76456a30e20f5d7f2e14a98a4ae2ee4e5abdc7c5ea0aafe795f344bc7984c", size = 36679, upload-time = "2025-08-27T15:39:50.179Z" },
-]
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.0.0" }]
 
 [[package]]
 name = "typing-extensions"
@@ -602,31 +320,10 @@ wheels = [
 ]
 
 [[package]]
-name = "typing-inspection"
-version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
-]
-
-[[package]]
 name = "tzdata"
-version = "2025.2"
+version = "2026.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380, upload-time = "2025-03-23T13:54:43.652Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839, upload-time = "2025-03-23T13:54:41.845Z" },
-]
-
-[[package]]
-name = "urllib3"
-version = "2.5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]

--- a/skills/route-researcher/tools/uv.lock
+++ b/skills/route-researcher/tools/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.11"
 
 [options]
-exclude-newer = "2026-05-15T08:53:55.090921Z"
+exclude-newer = "2026-05-15T10:31:17.75909Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -174,27 +174,6 @@ wheels = [
 ]
 
 [[package]]
-name = "markdown-it-py"
-version = "4.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mdurl" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
-]
-
-[[package]]
-name = "mdurl"
-version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
-]
-
-[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -269,19 +248,6 @@ wheels = [
 ]
 
 [[package]]
-name = "rich"
-version = "15.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markdown-it-py" },
-    { name = "pygments" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
-]
-
-[[package]]
 name = "route-researcher-tools"
 version = "0.1.0"
 source = { editable = "." }
@@ -290,7 +256,6 @@ dependencies = [
     { name = "click" },
     { name = "httpx" },
     { name = "patchright" },
-    { name = "rich" },
 ]
 
 [package.dev-dependencies]
@@ -304,7 +269,6 @@ requires-dist = [
     { name = "click", specifier = ">=8.1.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "patchright", specifier = ">=1.49.0" },
-    { name = "rich", specifier = ">=13.0.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Who's affected

Users of the `route-researcher` skill (`/mountaineering:research`, `/mountaineering:conditions`, `/mountaineering:trip-reports`) — reports now carry safety/emergency data, richer hazards, timing/itinerary, and pull from more sources. Driven by the author's Intermediate Glacier Climbing course notes.

## What changed

**Fetching foundation.** The dead `cloudscraper` fallback is replaced. `cloudscrape.py` now has a fast default path (httpx + browser-like headers) and a `--render` mode backed by **Patchright** (undetected Playwright, lazy Chromium install) for JavaScript-rendered / Cloudflare-protected pages. On failure it exits 0 with a JSON `{"error": ...}` note so the skill degrades gracefully and escalates to `--render`. Verified live: `--render` pulled full rendered HTML from the Cloudflare-protected hikeoftheweek.com.

**Safety / emergency geodata** (new, no API key — all degrade into `gaps` on failure):

| Output | Source | Example (Mt Baker, live) |
|--------|--------|--------------------------|
| Counties traversed | FCC Area API (trailhead→summit sampling, deduped by FIPS) | Whatcom County, WA |
| Nearest 24/7 hospital/ER | OSM Overpass | 3 ER hospitals w/ phone + distance |
| Nearest ranger station | OSM Overpass + USFS ArcGIS district | Heather Meadows VC; Mt. Baker Ranger District |
| Campgrounds | OSM Overpass | 37 nearby |

**Hazards & terrain.** Explicit, separately-tagged **Rockfall / Icefall-Serac / Cornice** callouts with timing mitigation, plus a Terrain Detail section (downclimbs, river crossings, water sources, named high camps) — extracted from trip reports/route beta.

**Conditions & timing overhaul.** Per-day freezing-level "snow line" with a within-2000ft-of-summit flag; nautical + astronomical twilight (for alpine-start planning); roped (~1 mi/hr glacier) vs unroped (~1000 ft/hr) speed models alongside pace tiers; NOAA + Meteoblue ranked most reliable (+ Mountain-Forecast / Windy); expanded road/trailhead closure detail (USFS closures, washouts, gates, CalTopo + Google Maps).

**Itinerary & navigation (Phase 5).** A schedule generator (start → summit ETA → turnaround-by → return, with an after-dark safety flag and `(+1d)` markers for cross-midnight finishes), great-circle navigation bearings, and a post-climb trip-report template.

**New sources.** Hike of the Week (via `--render`), NWHikers, Cascade Climbers, Mountain Project, Oregon Hikers.

**Also:** `peakbagger-cli` bumped to `git@v1.10.0`; orphan Node port deleted; `cloudscraper`/`rich` dependencies dropped; `docs/architecture.md` rewritten.

## Notable decisions

- **`peakbagger-cli` stays on the git pin (`git@v1.10.0`), not PyPI.** It is not published to PyPI (404) — a PyPI specifier would break all peak-data fetching. Git tags pin exactly, satisfying the ≥1.10.0 intent reproducibly.
- **Roped time uses `max(distance-rate, gain-rate)`**, not the lecture's pure 1 mi/hr — it never *underestimates* time, the safety-correct choice for glacier travel; both raw figures are still shown.
- **OSM Overpass requires an explicit User-Agent** — the public instance returns HTTP 406 to the default `python-httpx` UA. This was caught only in live end-to-end testing (mocked unit tests passed); fixed and re-verified live.
- Backcountry/high camps are intentionally sourced from trip reports, not a campground API (no DB covers them).
- First commit initializes `bd` (beads) issue tracking — incidental repo infra.

## Agent context

- Contracts changed: `fetch_conditions.py` output gains `counties`, `nearest_hospital`, `ranger_station`, `campgrounds`, `time_estimates`, `itinerary`, `bearings`; weather days gain `snow_line_note`/`near_summit`; daylight gains nautical/astronomical twilight. All optional keys emitted only when their inputs/flags are provided. `gaps` is an array of `{"source","reason"}` objects.
- New CLI flags: `--trailhead`, `--distance-mi`, `--gain-ft`, `--start-time`, `--waypoint` (repeatable).
- Fetching ladder: WebFetch → `cloudscrape.py` (httpx) → `cloudscrape.py --render` (Patchright). Failure signal is a JSON `{"error":...}` on stdout, not empty output.
- Scope boundary: does NOT wire up `mountaineers-mcp` (deferred); no UI; report-generation prose unchanged except new sections.
- Tests: 105 unit (mocked HTTP/no real browser); all features additionally verified against live APIs.
- Rollback risk: safe to revert (additive; graceful degradation throughout).