### PR TITLE
chore(release): 5.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
         "url": "https://github.com/dreamiurg/claude-mountaineering-skills.git"
       },
       "description": "Automated mountain route research combining PeakBagger data, weather forecasts, avalanche conditions, and trip reports into comprehensive beta documents",
-      "version": "4.0.2"
+      "version": "5.0.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mountaineering",
-  "version": "4.0.2",
+  "version": "5.0.0",
   "description": "Automated mountain route research combining PeakBagger data, weather forecasts, avalanche conditions, and trip reports into comprehensive beta documents",
   "author": {
     "name": "dreamiurg",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+## [5.0.0](https://github.com/dreamiurg/claude-mountaineering-skills/compare/v4.0.2...v5.0.0) (2026-05-22)
+
+
+### ⚠ BREAKING CHANGES
+
+* The plugin was renamed to `mountaineering` and now ships slash commands. Reinstall: `/plugin uninstall mountaineering-skills` then `/plugin install mountaineering@mountaineering-marketplace` ([#73](https://github.com/dreamiurg/claude-mountaineering-skills/pull/73)).
+
+
+### Features
+
+* **route-researcher:** safety/emergency geodata — counties traversed, nearest 24/7 hospital, nearest ranger station, and campgrounds via FCC + OSM Overpass + USFS ArcGIS (no API key) ([#78](https://github.com/dreamiurg/claude-mountaineering-skills/pull/78))
+* **route-researcher:** Patchright `--render` fetching engine replacing the dead cloudscraper fallback — reliably fetches JavaScript-rendered / Cloudflare-protected pages ([#78](https://github.com/dreamiurg/claude-mountaineering-skills/pull/78))
+* **route-researcher:** explicit rockfall / icefall / cornice hazard callouts plus terrain detail — downclimbs, river crossings, water sources, named camps ([#78](https://github.com/dreamiurg/claude-mountaineering-skills/pull/78))
+* **route-researcher:** conditions overhaul — snow-line / freezing-level emphasis, nautical & astronomical twilight, roped vs unroped speed models, NOAA + Meteoblue source ranking, expanded road/trailhead closure detail ([#78](https://github.com/dreamiurg/claude-mountaineering-skills/pull/78))
+* **route-researcher:** itinerary/schedule generator, navigation bearings, and a post-climb trip-report template ([#78](https://github.com/dreamiurg/claude-mountaineering-skills/pull/78))
+* **route-researcher:** add sources — Hike of the Week, NWHikers, Cascade Climbers, Mountain Project, Oregon Hikers ([#78](https://github.com/dreamiurg/claude-mountaineering-skills/pull/78))
+* rename plugin to mountaineering and add slash commands ([#73](https://github.com/dreamiurg/claude-mountaineering-skills/pull/73))
+* add JSON Schema validation for `.claude-plugin/` files ([#71](https://github.com/dreamiurg/claude-mountaineering-skills/pull/71))
+
+
+### Bug Fixes
+
+* **route-researcher:** set an Overpass User-Agent so the geodata fetchers work against the live API (was HTTP 406) ([#78](https://github.com/dreamiurg/claude-mountaineering-skills/pull/78))
+* **route-researcher:** pin peakbagger-cli to git@v1.10.0 (it is not published on PyPI) ([#78](https://github.com/dreamiurg/claude-mountaineering-skills/pull/78))
+* **ci:** run the route-researcher tools tests via uv and gate on them — deps were never installed and failures were swallowed ([#78](https://github.com/dreamiurg/claude-mountaineering-skills/pull/78))
+* **release:** bump root `package.json` in `update-versions.js` so every version file stays in sync
+
 ## [4.0.2](https://github.com/dreamiurg/claude-mountaineering-skills/compare/v4.0.1...v4.0.2) (2026-01-30)
 
 

--- a/package.json
+++ b/package.json
@@ -1,13 +1,17 @@
 {
   "name": "claude-mountaineering-skills",
-  "version": "4.0.1",
+  "version": "5.0.0",
   "description": "Claude Code plugin for North American mountain route research",
   "private": true,
   "repository": {
     "type": "git",
     "url": "git@github.com:dreamiurg/claude-mountaineering-skills.git"
   },
-  "keywords": ["claude-code", "mountaineering", "climbing"],
+  "keywords": [
+    "claude-code",
+    "mountaineering",
+    "climbing"
+  ],
   "author": "dreamiurg",
   "license": "MIT",
   "devDependencies": {

--- a/scripts/update-versions.js
+++ b/scripts/update-versions.js
@@ -11,6 +11,13 @@ if (!version) {
 
 console.log(`Updating version to ${version}`);
 
+// Update root package.json
+const packageJsonPath = path.join(__dirname, '..', 'package.json');
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+packageJson.version = version;
+fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n');
+console.log(`✓ Updated ${packageJsonPath}`);
+
 // Update plugin.json
 const pluginJsonPath = path.join(__dirname, '..', '.claude-plugin', 'plugin.json');
 const pluginJson = JSON.parse(fs.readFileSync(pluginJsonPath, 'utf8'));

--- a/skills/route-researcher/SKILL.md
+++ b/skills/route-researcher/SKILL.md
@@ -849,4 +849,4 @@ Example: `https://www.google.com/maps/search/?api=1&query=Cascade+Pass+Trailhead
 
 ---
 
-**Skill Version:** 4.0.3 | **Last Updated:** 2026-01-31
+**Skill Version:** 5.0.0 | **Last Updated:** 2026-05-22


### PR DESCRIPTION
Cuts **v5.0.0**. Major bump because the unreleased plugin rename (#73, `feat!`) is a breaking change, on top of the route-researcher enrichment (#78).

## What's in this PR
- Bump all version files to 5.0.0: `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `skills/route-researcher/SKILL.md`
- Add the 5.0.0 CHANGELOG entry (covers v4.0.2..HEAD)
- **Fix** `scripts/update-versions.js` to also bump root `package.json` — it was omitted, so package.json had drifted to 4.0.1 while the rest were 4.0.2/4.0.3

## Notable
- Semantic-release has been unable to auto-cut releases since ~March (its bot push to `main` is rejected by branch protection: "changes must be made through a pull request"). This PR cuts the release through the normal PR flow; the tag + GitHub Release are created manually after merge.
- Version files are now unified — this also fixes the pre-existing 4.0.1/4.0.2/4.0.3 drift.

## Agent context
- Scope boundary: version/changelog only; no functional code changes.
- Rollback risk: safe (metadata only).