### PR TITLE
ci(release): fix Verify-scripts step corrupting version files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,8 @@ jobs:
 
       - name: Verify scripts
         run: |
-          test -f scripts/update-versions.js
-          node scripts/update-versions.js --help || true
+          node --check scripts/update-versions.js
+          node --check scripts/sync-changelog-to-readme.js
 
       - name: Release
         env:


### PR DESCRIPTION
## What
The Release workflow's "Verify scripts" step ran `node scripts/update-versions.js --help`. That script uses its first CLI arg as the version, so `--help` made it rewrite `package.json`, `plugin.json`, `marketplace.json`, and `SKILL.md` to the literal string `"--help"` in the CI workspace. It was only masked because semantic-release's prepare step overwrote them with the real version moments later (and the push fails anyway under branch protection).

Replaced with `node --check` syntax validation of both release scripts — a real smoke test with no side effects.

## Not addressed here (needs a repo-owner decision)
Auto-releases have been failing since ~March: `@semantic-release/git` pushes the version-bump commit directly to `main`, but the `main` ruleset requires all changes go through a PR (its only bypass actor is admin with `bypass_mode: pull_request`). Options: add a GitHub App as an `always`-bypass actor and authenticate the release job as it; or move to a PR-based release flow; or drop `@semantic-release/git` and tag/release only. See the v5.0.0 release notes — that release was cut manually through the PR flow.

## Agent context
- Scope boundary: CI workflow only; no functional code.
- Rollback risk: safe.