### PR TITLE
feat(route-researcher): linked locations/sources, active road-gate status, richer emergency contacts

### DIFF
--- a/skills/route-researcher/SKILL.md
+++ b/skills/route-researcher/SKILL.md
@@ -805,27 +805,44 @@ Common variations to try if initial search fails:
 - **Remove title:** "Baker" instead of "Mt Baker"
 - **Combine variations:** Try reversed order with title expansion (e.g., "Mountain Pratt" → "Pratt Mount" + "Pratt Mountain")
 
-### Google Maps and USGS Links
+### Navigation Map Links
 
 #### Summit Coordinates Links
 
-**Google Maps (for summit coordinates):**
+Build these centered on the summit (decimal degrees) for the report Overview line.
+
+**Google Maps:**
 
 ```
 https://www.google.com/maps/search/?api=1&query={latitude},{longitude}
 ```
 
-Example: `https://www.google.com/maps/search/?api=1&query=48.7768,-121.8144`
-
-**USGS TopoView (for summit coordinates):**
+**CalTopo** (MapBuilder Topo base, zoom 14):
 
 ```
-https://ngmdb.usgs.gov/topoview/viewer/#17/{latitude}/{longitude}
+https://caltopo.com/map.html#ll={latitude},{longitude}&z=14&b=mbt
 ```
 
-Example: `https://ngmdb.usgs.gov/topoview/viewer/#17/48.7768/-121.8144`
+**Gaia GPS** (order is zoom/longitude/latitude):
 
-**Note:** Use decimal degree format for coordinates. TopoView uses zoom level in URL (15-17 works well for peaks).
+```
+https://www.gaiagps.com/map/?loc=14/{longitude}/{latitude}
+```
+
+**PeakVisor hiking map** (zoom/latitude/longitude; slashes URL-encoded as `%2F` in the query):
+
+```
+https://peakvisor.com/hiking-map?custom=14%2F{latitude}%2F{longitude}#14/{latitude}/{longitude}
+```
+
+Example (Mt Baker, 48.7768, -121.8144):
+
+- Google Maps: `https://www.google.com/maps/search/?api=1&query=48.7768,-121.8144`
+- CalTopo: `https://caltopo.com/map.html#ll=48.7768,-121.8144&z=14&b=mbt`
+- Gaia GPS: `https://www.gaiagps.com/map/?loc=14/-121.8144/48.7768`
+- PeakVisor: `https://peakvisor.com/hiking-map?custom=14%2F48.7768%2F-121.8144#14/48.7768/-121.8144`
+
+**Note:** Use decimal degrees. Gaia GPS expects zoom/longitude/latitude order; CalTopo and PeakVisor use latitude then longitude.
 
 #### Trailhead Google Maps Links
 

--- a/skills/route-researcher/SKILL.md
+++ b/skills/route-researcher/SKILL.md
@@ -160,9 +160,9 @@ This returns JSON with:
 - **avalanche**: NWAC region and URL for manual check
 - **peakbagger**: Ascent statistics and recent ascents (if peak_id provided)
 - **counties**: Counties traversed trailhead→summit (`counties[]` with `county_name`, `county_fips`, `state_name`, `state_code`); `sampled` bool and `sample_points` int indicate whether path sampling ran (requires `--trailhead`); without `--trailhead` only the summit county is returned
-- **nearest_hospital**: Nearest hospitals/ERs (`hospitals[]` with `name`, `distance_miles`, `emergency`, `phone` (optional — omitted when OSM has no phone tag)); sorted emergency-first then by distance; max 3
-- **ranger_station**: Nearest ranger stations (`stations[]` with `name`, `distance_miles`, `phone`, `website`) + optional `admin_district` (`district_name`, `forest_name`, `region`) when the summit coordinates intersect a USFS ranger district
-- **campgrounds**: Established campgrounds within ~12 mi (20 km) (`campgrounds[]` with `name`, `distance_miles`, `camp_type`, `backcountry`, `operator`); backcountry/high camps are NOT included — extract those from trip reports
+- **nearest_hospital**: Nearest hospitals/ERs (`hospitals[]` with `name`, `lat`, `lon`, `distance_miles`, `emergency`, and `phone`/`website`/`address` when OSM has them); sorted emergency-first then by distance; max 3
+- **ranger_station**: Nearest ranger stations (`stations[]` with `name`, `lat`, `lon`, `distance_miles`, and `phone`/`website`/`address` when present) + optional `admin_district` (`district_name`, `forest_name`, `region`) when the summit coordinates intersect a USFS ranger district
+- **campgrounds**: Established campgrounds within ~12 mi (20 km) (`campgrounds[]` with `name`, `lat`, `lon`, `distance_miles`, `camp_type`, `backcountry`, `operator`, and `website` when present); backcountry/high camps are NOT included — extract those from trip reports
 - **gaps**: Any API failures noted for report
 
 **Run this in parallel with Step 3B** — include both the Bash command for fetch_conditions.py and all 3 Task calls in the same response turn to maximize parallelism.
@@ -408,18 +408,28 @@ After Python script and all agents return, aggregate into unified data structure
 - Note failed sources in the gaps array
 - Minimum viable: conditions data + at least one route source
 
-#### Step 3D: Access and Permits (Inline)
+#### Step 3D: Access, Permits, and Road/Gate Status (Inline)
 
-Run WebSearch for access information:
+Determine permits AND the **current road/gate status** to the trailhead — do not just tell the user to go check. Actively research and report the actual status with a source and date.
+
+**Permits:**
 
 ```
-WebSearch queries:
-1. "{peak_name} trailhead access"
-2. "{peak_name} permit requirements"
-3. "{peak_name} forest service road conditions"
+WebSearch: "{peak_name} trailhead access" ; "{peak_name} permit requirements"
 ```
 
-Extract trailhead names, required permits, access notes. Add to route_data.
+**Road / gate status workflow** (identify the access highway + forest road + managing agency first, then check sources in order; capture each source URL for the report):
+
+1. **State DOT pass report** (WA → WSDOT): fetch the relevant pass page, e.g. `https://wsdot.com/travel/real-time/mountainpasses/mt.-baker` (SR-542) or `.../north-cascades` (SR-20). Read `RoadCondition` / `TravelAdvisoryActive` / restrictions. Other states: `WebSearch "{state} DOT mountain pass report {highway}"`.
+2. **USFS forest alerts/conditions**: fetch `https://www.fs.usda.gov/{region}/{forest-shortname}/alerts` (e.g. `r06/mbs/alerts`) and `/conditions`; search the page for the road number / trailhead name → closure milepost, reason, seasonal gate. Also `WebSearch "{forest name} {road or trailhead} road open {year}"` for seasonal-opening press releases.
+3. **NPS road conditions** (if in/through a national park): fetch `https://www.nps.gov/{park-code}/planyourvisit/road-conditions.htm` (e.g. `noca`, `mora`, `olym`) → per-road OPEN/CLOSED + milepost.
+4. **WTA ground truth** (PNW): `WebSearch "site:wta.org {trail} gate road open closed {year}"` or fetch the hike page; scan the 3-5 most recent trip reports for "gate"/"road open/closed"/"drove to" (use `cloudscrape.py --render` if WTA 403s).
+5. **InciWeb fire closures** (Jul-Oct): `WebSearch "inciweb {area} closure {trailhead} {year}"`; if an active incident is near the trailhead, read its closure page.
+
+**Synthesize** into a dated status statement for the report's Road Conditions section:
+> "Gate/road status (as of {date}): {road} is {OPEN/CLOSED/SEASONAL GATE/UNKNOWN} per [source](url). {If closed: gate at {milepost}, adds ~{N} mi each way.}"
+
+If no source confirms it, say so explicitly and include the managing ranger station phone as the fallback. Add trailhead names, permits, the status statement, and all source URLs to route_data.
 
 ### Phase 4: Route Analysis
 
@@ -491,11 +501,20 @@ From all synthesized data, identify:
 
 #### Step 4C: Surface Geodata in Report
 
-Include these geodata fields in the report when available:
+Include these geodata fields when available. **Every place named in the report must be a link** — see the link patterns below.
 
-- **Counties:** List `county_name + state_name` from `conditions.counties.counties[]` in the Overview section. If the array is empty or `error` is present, note in Information Gaps.
-- **Emergency contacts:** Populate the Emergency Contacts section from `conditions.nearest_hospital.hospitals[]` and `conditions.ranger_station` (stations + admin_district). If either is missing or has an `error` key, note in Information Gaps and direct the user to check manually.
-- **Campgrounds:** Populate the Camping section from `conditions.campgrounds.campgrounds[]`. Explicitly state that backcountry/high camps are not in this list and must be extracted from trip reports.
+**Place / map link patterns** (build from a place's `lat`/`lon` and `name`):
+
+- Google Maps **place** (named entity): `https://www.google.com/maps/search/?api=1&query={URL-encoded name + address}` — use this (not bare coordinates) for hospitals, ranger stations, campgrounds, and any named place, so the link resolves to the actual entity. When only coordinates are meaningful, `query={lat},{lon}`.
+- Gaia GPS: `https://www.gaiagps.com/map/?loc=14/{lon}/{lat}` (zoom/lon/lat).
+- CalTopo: `https://caltopo.com/map.html#ll={lat},{lon}&z=14&b=mbt`.
+
+Surfacing rules:
+
+- **Counties:** list `county_name + state_name` from `conditions.counties.counties[]` in the Overview. Empty/`error` → Information Gaps.
+- **Emergency contacts:** build the table from `conditions.nearest_hospital.hospitals[]` and `conditions.ranger_station` (stations + admin_district). **Link each name** to its `website` if present, else a Google Maps place search by `name + address`. **Always include phone AND address columns** — each entry now carries `phone`/`website`/`address`/`lat`/`lon` when OSM has them; if `phone` or `address` is missing, make a best effort to find the entity's real phone/address (its official site or Google Maps listing) before writing "—". Missing/`error` → note in Information Gaps.
+- **Campgrounds:** build the Camping table from `conditions.campgrounds.campgrounds[]`; link the name (website or Google Maps place) and add Google Maps + Gaia map links from each entry's `lat`/`lon`.
+- **Any named location report-wide** (campsite, bivy, high camp, named feature, trailhead): accompany with at least Google Maps + Gaia links, per the patterns above. For trip-report-named camps without coordinates, use a Google Maps place search by name and do your best to locate it; if it cannot be located, say so explicitly. Backcountry/high camps come from trip reports, not the campground DB.
 
 #### Step 4D: Identify Information Gaps
 
@@ -533,9 +552,9 @@ Organize all gathered and analyzed data into structured JSON:
     "avalanche": {...},
     "peakbagger": {...},
     "counties": {"counties": [{"county_name": "...", "county_fips": "...", "state_name": "...", "state_code": "..."}], "sampled": bool, "sample_points": N},  // sampled + sample_points only present when --trailhead was given
-    "nearest_hospital": {"hospitals": [{"name": "...", "distance_miles": N, "emergency": "yes|null", "phone": "..." /* optional */}]},
-    "ranger_station": {"stations": [{"name": "...", "distance_miles": N, "phone": null, "website": null}], "admin_district": {"district_name": "...", "forest_name": "...", "region": "..."}},
-    "campgrounds": {"campgrounds": [{"name": "...", "distance_miles": N, "camp_type": "..."}], "note": "..."},
+    "nearest_hospital": {"hospitals": [{"name": "...", "lat": N, "lon": N, "distance_miles": N, "emergency": "yes|null", "phone": "...", "website": "...", "address": "..." /* phone/website/address optional */}]},
+    "ranger_station": {"stations": [{"name": "...", "lat": N, "lon": N, "distance_miles": N, "phone": "...", "website": "...", "address": "..." /* optional */}], "admin_district": {"district_name": "...", "forest_name": "...", "region": "..."}},
+    "campgrounds": {"campgrounds": [{"name": "...", "lat": N, "lon": N, "distance_miles": N, "camp_type": "...", "operator": "...", "website": "..." /* optional */}], "note": "..."},
     "time_estimates": {"roped_hr": N, "unroped_hr": N, "fast_hr": N, "moderate_hr": N, "leisurely_hr": N, "note": "..."},
     "itinerary": {"start_time": "HH:MM", "summit_eta": "HH:MM", "turnaround_by": "HH:MM", "return_eta": "HH:MM", "total_hr": N, "after_dark": false, "dusk_cutoff": "9:15 PM" /* 12-hr AM/PM format, unlike other time fields */, "note": "..."},
     "bearings": {"segments": [{"from": 0, "to": 1, "bearing_deg": N, "distance_mi": N, "cumulative_distance_mi": N}], "total_distance_mi": N}
@@ -661,6 +680,12 @@ Task(
    - AI disclaimer present and prominent
    - Critical hazards properly emphasized
    - Users directed to verify information from primary sources
+
+   **Emergency contacts & location links (verify INDEPENDENTLY):**
+   - Each emergency contact (hospital, ranger station) has a working name link (website or a Google Maps place link to the actual entity — NOT bare coordinates), a phone, and an address. Independently confirm the phone/address look right for that named entity (e.g. via its official site / Google Maps); fix or flag mismatches and fill blanks you can confirm.
+   - Road/gate status is a dated statement with a cited source, not a "go check it yourself" punt.
+   - Every named place in the report (campsite, bivy, high camp, trailhead, named feature) carries map links (Google Maps + Gaia GPS). Flag any named location missing links.
+   - Specific trip-report attributions are hyperlinks to their source, not plain text.
 
 3. **Fix issues:**
    - **Critical** (safety errors, factual errors, missing disclaimers): MUST fix using Edit tool

--- a/skills/route-researcher/SKILL.md
+++ b/skills/route-researcher/SKILL.md
@@ -451,9 +451,10 @@ Based on route descriptions, elevation, and gear mentions, classify as:
 3. **Note conflicts** when trip reports disagree with published info
 4. **Highlight consensus** ("Multiple reports mention...")
 5. **Include specifics** (elevations, locations, quotes)
+6. **Link every specific-report attribution to its source.** Whenever a detail is drawn from a *particular* trip/climb report (a date, a quote, "one party found…", "a recent report noted…"), the attribution MUST be a Markdown hyperlink to that report's URL — never plain text. Carry each trip report's `url` (and date/author) through synthesis so it can be linked; use the date/author as the link text. For consensus phrasing ("multiple reports mention…"), link 2-3 of the contributing reports inline. Only general/published beta with no specific source stays unlinked.
 
 **Example (Route Description):**
-> "The standard route follows the East Ridge (Class 3). Multiple trip reports mention a well-cairned use trail branching right at 4,800 ft—this is the correct turn. The use trail climbs through talus (described as 'tedious' and 'ankle-rolling'). In early season, this section may be snow-covered, requiring microspikes."
+> "The standard route follows the East Ridge (Class 3). A [Sep 2025 party](https://www.peakbagger.com/climber/ascent.aspx?aid=12345) found a well-cairned use trail branching right at 4,800 ft—the correct turn—through talus they called 'tedious' and 'ankle-rolling'. An [Oct 2025 report](https://www.wta.org/go-hiking/trip-reports/trip_report.123) noted the section was snow-covered, requiring microspikes."
 
 **Apply this pattern to:**
 
@@ -587,6 +588,7 @@ Task(
    - Use `-` for bullets (not `*` or `+`)
    - Use `**text**` for bold emphasis
    - Break paragraphs >4 sentences
+   - **Link specific-report attributions.** Any statement attributed to a particular trip/climb report (a date, a quote, "one party…", "a recent report…") MUST be a Markdown link `[date/author](report_url)` to that report's source URL — never plain-text attribution. Pull the URL from the matching `trip_reports[].url` in the data package. Leave only generic/published beta (no specific source) unlinked.
 
 4. **Save the report:**
    Use the Write tool to save to the user's current working directory: {date}-{peak-name-slug}.md

--- a/skills/route-researcher/assets/report-template.md
+++ b/skills/route-researcher/assets/report-template.md
@@ -111,7 +111,7 @@ No established campgrounds found in OSM data near this trailhead. Check Recreati
 
 ### Route Description
 
-{Route description synthesized from multiple sources}
+{Route description synthesized from multiple sources. Whenever a detail comes from a specific trip/climb report, hyperlink the attribution to that report's URL — e.g., "a [Sep 2025 party](report_url) found…" — never plain-text attribution. This applies throughout the report (Route, Crux, Hazards, Terrain Detail, Conditions): cite specific reports as links, not bare words.}
 
 The route covers approximately **{round trip distance}** with **{total gain}** of elevation gain.
 

--- a/skills/route-researcher/assets/report-template.md
+++ b/skills/route-researcher/assets/report-template.md
@@ -22,7 +22,7 @@
 
 ## Overview
 
-{Peak name} rises to **{elevation with units}** with {prominence with units} of prominence in the {state, range}. The peak is located at {latitude}, {longitude} ([Google Maps]({google_maps_coordinates_link}) | [USGS Topo]({usgs_topo_link})). The standard route is a **{route type}** rated **{difficulty}**.
+{Peak name} rises to **{elevation with units}** with {prominence with units} of prominence in the {state, range}. The peak is located at {latitude}, {longitude} ([Google Maps]({google_maps_coordinates_link}) | [CalTopo]({caltopo_link}) | [Gaia GPS]({gaia_gps_link}) | [PeakVisor]({peakvisor_link})). The standard route is a **{route type}** rated **{difficulty}**.
 
 {1-2 sentence synthesized description of the route character, typical approach, and what makes it notable or challenging. Example: "The route follows a classic alpine traverse combining glacier travel with moderate scrambling. Most parties complete the climb in a long day from the trailhead, navigating crevassed terrain on the approach glacier before tackling exposed rock near the summit."}
 

--- a/skills/route-researcher/assets/report-template.md
+++ b/skills/route-researcher/assets/report-template.md
@@ -53,61 +53,49 @@
 
 #### Road Conditions
 
-{Current access notes. Extract from researcher agents: USFS road closures, seasonal gate status, washouts, fire closures. Be explicit — note the specific road number/name and any reported obstacles.}
+**Gate / road status (as of {date researched}):** {State the ACTUAL current status determined by the road/gate research workflow (SKILL.md Step 3D). Name the specific highway/forest road, say **OPEN / CLOSED / SEASONAL GATE / UNKNOWN**, give the gate location/milepost and added on-foot mileage if closed, and cite the source as a link. Example: "The upper 2.7 mi of SR-542 to Artist Point is **closed (seasonal snow gate)** as of 2026-05-22 per [WSDOT]({wsdot_pass_link}) and a [June 8 WTA report]({wta_report_link}); park at the lower gate and add ~2.7 mi each way."}
 
-{If no current closure info found:} Road status not confirmed. Verify before departure.
+{If status could not be confirmed from any source:} Road/gate status **not confirmed** from automated sources — verify before driving via the links/phone below.
 
-**Verify current status:**
+**Sources checked / verify 24-48 hr before departure:**
 
-- [USFS Road Conditions](https://www.fs.usda.gov/) — search ranger district for road/gate closures
-- [CalTopo Closure Layers](https://caltopo.com/) — enable "Closures" layer; pin trailhead at `https://caltopo.com/map.html#ll={latitude},{longitude}&z=14`
-- [Google Maps]({google_maps_trailhead_link}) — check current road status and satellite view
-- [Recreation.gov](https://www.recreation.gov/) — permit/reservation requirements
+- [WSDOT pass report]({wsdot_pass_link}) — state-highway gate/restriction status (WA routes)
+- [{forest name} alerts]({usfs_alerts_link}) — USFS road closures & seasonal gates
+- [NPS road conditions]({nps_roads_link}) — if accessed via a national park
+- [CalTopo]({caltopo_trailhead_link}) (enable "Closures" layer) · [Google Maps]({google_maps_trailhead_link})
+- [Recreation.gov](https://www.recreation.gov/) — permits/reservations
+- {Ranger station phone — for direct confirmation when web sources are inconclusive}
 
 ### Emergency Contacts
 
-{If ranger_station data available:}
+> Dial **911** (or trigger a satellite-messenger / PLB SOS) in an emergency. Backcountry rescue is coordinated by the managing agency (NPS / USFS) and the county sheriff/SAR.
 
-**Nearest Ranger Station:**
+{Build the table below. Link each **Resource name** to its official website if available, otherwise to a Google Maps **place** search by name + address — `https://www.google.com/maps/search/?api=1&query={URL-encoded name + address}` — NOT bare GPS coordinates. Always populate Phone and Address: if missing from OSM, do your best to find the entity's real phone/address (official site or Google Maps listing) rather than leaving blank; if still unknown, write "—". List up to 3 hospitals (prefer emergency=yes) plus the nearest ranger station.}
 
-- **{station name}** — {distance_miles} mi ({admin_district.district_name}, {admin_district.forest_name} if on NF land)
-  {Phone: {phone} if available}
-  {Website: {website} if available}
+| Resource | Distance | Phone | Address |
+|----------|----------|-------|---------|
+| [{hospital name}]({website_or_google_maps_place}) {(ER) if emergency=yes} | {distance_miles} mi | {phone or —} | {address or —} |
+| [{ranger station name}]({website_or_google_maps_place}) | {distance_miles} mi | {phone or —} | {address or —} |
 
-{If admin_district present:}
-*Administrative district: {district_name}, {forest_name} ({region})*
+{If admin_district present:} *Managing district: {district_name}, {forest_name} ({region}).*
 
-{If ranger_station unavailable or error:}
-**Nearest Ranger Station:** Data not available (OSM). Check with local forest service or park service.
+*Hospital/ranger data is from OpenStreetMap and may be incomplete in remote/border areas. Phone and address are independently re-checked by the Report Reviewer; verify before travel.*
 
-{If nearest_hospital data available:}
-
-**Nearest 24/7 Hospital / Emergency Room:**
-
-- **{hospital name}** — {distance_miles} mi {(emergency=yes if tagged)}
-  {Phone: {phone} if available}
-
-{List up to 3 hospitals from hospitals[]. Prefer emergency=yes entries.}
-
-*Note: Hospital data is sourced from OpenStreetMap and may be incomplete or outdated in remote areas. Verify locations before travel.*
-
-{If nearest_hospital unavailable or error:}
-**Nearest Hospital:** Data not available. Check local emergency services for the area.
+{If nearest_hospital and ranger_station are both unavailable:} Emergency-services data not available from OSM for this area — look up the nearest hospital and managing ranger district/park dispatch directly before your trip.
 
 ### Camping
 
 **Established campgrounds near trailhead** *(within ~12 mi (20 km), OSM data):*
 
-{If campgrounds available:}
+{If campgrounds available — link the campground name to its website or a Google Maps place search by name, and add Map links built from its lat/lon:}
 
-| Campground | Distance | Type | Operator |
-|------------|----------|------|----------|
-| {name} | {distance_miles} mi | {camp_type} | {operator or —} |
+| Campground | Distance | Type | Operator | Map |
+|------------|----------|------|----------|-----|
+| [{name}]({website_or_google_maps_place}) | {distance_miles} mi | {camp_type or —} | {operator or —} | [Google Maps](https://www.google.com/maps/search/?api=1&query={lat},{lon}) · [Gaia](https://www.gaiagps.com/map/?loc=14/{lon}/{lat}) |
 
-{If no campgrounds found or error:}
-No established campgrounds found in OSM data near this trailhead. Check Recreation.gov or the local ranger district.
+{If no campgrounds found or error:} No established campgrounds in OSM near this trailhead. Check Recreation.gov or the local ranger district.
 
-**Backcountry and high camps** are not in any database — locations and conditions are extracted from trip reports and route beta in the Trip Reports and Route Description sections above.
+**Location-linking rule (applies report-wide):** Every named place this report brings up — campground, backcountry/high camp, bivy site, trailhead, named feature — MUST be accompanied by map links: at minimum [Google Maps] and [Gaia GPS]. Build them from coordinates when known (`https://www.gaiagps.com/map/?loc=14/{lon}/{lat}` and `https://www.google.com/maps/search/?api=1&query={lat},{lon}`); when only a name is known (e.g. a high camp from a trip report), use a Google Maps place search by name and do your best to locate it. If a place genuinely can't be located, say so explicitly rather than omitting the attempt. Backcountry/high camps come from trip reports and route beta (see Trip Reports and Terrain Detail), not the campground database.
 
 ### Route Description
 

--- a/skills/route-researcher/assets/trip-report-template.md
+++ b/skills/route-researcher/assets/trip-report-template.md
@@ -1,5 +1,7 @@
 # Trip Report: {Route Name} via {Route}
 
+> Generated with the [mountaineering route-researcher skill](https://github.com/dreamiurg/claude-mountaineering-skills).
+
 **Date:** {YYYY-MM-DD}
 **Party size:** {N}
 **Summit reached:** Yes / No / Turned around at {location}

--- a/skills/route-researcher/docs/architecture.md
+++ b/skills/route-researcher/docs/architecture.md
@@ -89,9 +89,9 @@ All keys are top-level in the returned JSON object. Optional keys are emitted on
 | `avalanche` | always | NWAC region + URL |
 | `peakbagger` | when `--peak-id` provided | ascent stats + recent ascents |
 | `counties` | always | `counties[]` with `county_name`, `county_fips`, `state_name`, `state_code`; `sampled` bool (true when trailhead→summit path sampling ran), `sample_points` int |
-| `nearest_hospital` | always | `hospitals[]` — name, distance_miles, emergency, phone (optional — omitted when OSM has no phone tag); sorted emergency-first |
-| `ranger_station` | always | `stations[]` + optional `admin_district` (district_name, forest_name, region) when summit coordinates intersect a USFS ranger district |
-| `campgrounds` | always | `campgrounds[]` within ~12 mi (20 km) — name, distance_miles, camp_type, backcountry, operator |
+| `nearest_hospital` | always | `hospitals[]` — name, lat, lon, distance_miles, emergency, + phone/website/address when OSM has them; sorted emergency-first |
+| `ranger_station` | always | `stations[]` (name, lat, lon, distance_miles, + phone/website/address when present) + optional `admin_district` (district_name, forest_name, region) |
+| `campgrounds` | always | `campgrounds[]` within ~12 mi (20 km) — name, lat, lon, distance_miles, camp_type, backcountry, operator, + website when present |
 | `time_estimates` | `--distance-mi` + `--gain-ft` | roped_hr, unroped_hr, fast_hr, moderate_hr, leisurely_hr, note |
 | `itinerary` | `--start-time` + `--distance-mi` + `--gain-ft` | start_time, summit_eta, turnaround_by, return_eta, total_hr, after_dark bool, dusk_cutoff, note |
 | `bearings` | 2+ `--waypoint` args | segments[] (bearing_deg, distance_mi, cumulative_distance_mi) + total_distance_mi |

--- a/skills/route-researcher/tools/fetch_conditions.py
+++ b/skills/route-researcher/tools/fetch_conditions.py
@@ -396,6 +396,20 @@ def _osm_coords(el: dict) -> tuple[float | None, float | None]:
     return elat, elon
 
 
+def _osm_website(tags: dict) -> str | None:
+    """Best website URL from common OSM tags, if any."""
+    return tags.get("website") or tags.get("contact:website") or tags.get("url")
+
+
+def _osm_address(tags: dict) -> str | None:
+    """Compose a human address from OSM addr:* tags, if present."""
+    if tags.get("addr:full"):
+        return tags["addr:full"]
+    street = " ".join(p for p in (tags.get("addr:housenumber"), tags.get("addr:street")) if p)
+    locality = ", ".join(p for p in (tags.get("addr:city"), tags.get("addr:state")) if p)
+    return ", ".join(p for p in (street, locality) if p) or None
+
+
 _OVERPASS_HEADERS = {
     "User-Agent": (
         "claude-mountaineering-skills/route-researcher "
@@ -437,11 +451,17 @@ out center tags;
                 continue
             entry: dict[str, Any] = {
                 "name": tags.get("name", "Unknown hospital"),
+                "lat": elat,
+                "lon": elon,
                 "distance_miles": round(_haversine_miles(lat, lon, elat, elon), 1),
                 "emergency": tags.get("emergency"),
             }
             if "phone" in tags:
                 entry["phone"] = tags["phone"]
+            if _osm_website(tags):
+                entry["website"] = _osm_website(tags)
+            if _osm_address(tags):
+                entry["address"] = _osm_address(tags)
             hospitals.append(entry)
 
         # Sort: emergency=yes first, then by distance
@@ -474,14 +494,19 @@ out center tags;
             elat, elon = _osm_coords(el)
             if elat is None or elon is None:
                 continue
-            stations.append(
-                {
-                    "name": tags.get("name", "Unknown station"),
-                    "distance_miles": round(_haversine_miles(lat, lon, elat, elon), 1),
-                    "phone": tags.get("phone"),
-                    "website": tags.get("website"),
-                }
-            )
+            s_entry: dict[str, Any] = {
+                "name": tags.get("name", "Unknown station"),
+                "lat": elat,
+                "lon": elon,
+                "distance_miles": round(_haversine_miles(lat, lon, elat, elon), 1),
+            }
+            if tags.get("phone"):
+                s_entry["phone"] = tags["phone"]
+            if _osm_website(tags):
+                s_entry["website"] = _osm_website(tags)
+            if _osm_address(tags):
+                s_entry["address"] = _osm_address(tags)
+            stations.append(s_entry)
         stations.sort(key=lambda s: s["distance_miles"])
 
         result: dict[str, Any] = {"stations": stations[:3]}
@@ -537,15 +562,18 @@ out center tags;
             elat, elon = _osm_coords(el)
             if elat is None or elon is None:
                 continue
-            campgrounds.append(
-                {
-                    "name": tags.get("name", "Unnamed campground"),
-                    "distance_miles": round(_haversine_miles(lat, lon, elat, elon), 1),
-                    "camp_type": tags.get("camp_type"),
-                    "backcountry": tags.get("backcountry"),
-                    "operator": tags.get("operator"),
-                }
-            )
+            c_entry: dict[str, Any] = {
+                "name": tags.get("name", "Unnamed campground"),
+                "lat": elat,
+                "lon": elon,
+                "distance_miles": round(_haversine_miles(lat, lon, elat, elon), 1),
+                "camp_type": tags.get("camp_type"),
+                "backcountry": tags.get("backcountry"),
+                "operator": tags.get("operator"),
+            }
+            if _osm_website(tags):
+                c_entry["website"] = _osm_website(tags)
+            campgrounds.append(c_entry)
         campgrounds.sort(key=lambda c: c["distance_miles"])
 
         return {

--- a/skills/route-researcher/tools/test_geodata_fetchers.py
+++ b/skills/route-researcher/tools/test_geodata_fetchers.py
@@ -161,6 +161,11 @@ OVERPASS_HOSPITAL_RESPONSE = {
                 "amenity": "hospital",
                 "emergency": "yes",
                 "phone": "+1-360-734-5400",
+                "website": "https://www.peacehealth.org/st-joseph",
+                "addr:housenumber": "2901",
+                "addr:street": "Squalicum Pkwy",
+                "addr:city": "Bellingham",
+                "addr:state": "WA",
             },
         },
         {
@@ -214,6 +219,17 @@ class TestFetchNearestHospital:
 
         peace = next(h for h in result["hospitals"] if h["name"] == "PeaceHealth St. Joseph")
         assert peace.get("phone") == "+1-360-734-5400"
+
+    def test_website_address_and_coords_surfaced(self):
+        """website, composed address, and lat/lon are surfaced for linking."""
+        with patch("fetch_conditions.httpx.Client") as mock_cls:
+            mock_cls.return_value = _mock_httpx_post(OVERPASS_HOSPITAL_RESPONSE)
+            result = fetch_nearest_hospital(48.77, -121.81)
+
+        peace = next(h for h in result["hospitals"] if h["name"] == "PeaceHealth St. Joseph")
+        assert peace["website"] == "https://www.peacehealth.org/st-joseph"
+        assert peace["address"] == "2901 Squalicum Pkwy, Bellingham, WA"
+        assert peace["lat"] == 48.42 and peace["lon"] == -122.33
 
     def test_network_error_returns_error_dict(self):
         """Network failure returns error dict without raising."""


### PR DESCRIPTION
A batch of report-quality improvements (ships as v5.1.0).

## Changes
1. **Map links for the objective** — CalTopo, Gaia GPS, PeakVisor in the Overview; US Topo removed.
2. **Hyperlinked trip-report attributions** — any statement from a specific trip/climb report links to its source (synthesis pattern + Report Writer rules + template).
3. **Active road/gate status** — Step 3D now runs a concrete research workflow (WSDOT pass reports, USFS forest alerts/conditions, NPS road pages, WTA trip reports, InciWeb) and reports a dated status with source links, instead of telling the user to go check.
4. **Linked emergency contacts with phone + address** — geodata fetchers now return lat/lon/website/address; the Emergency Contacts table links each name (website or a Google Maps *place*, not bare coords) and always shows phone + address. The Report Reviewer independently verifies these.
5. **Every named location is map-linked** — campsites/bivies/high camps/trailheads get Google Maps + Gaia GPS links (coords when known, place search by name otherwise).
6. **Trip-report template** links the GitHub repo at the top.

## Notable
- Re-added `lat`/`lon` to the geodata fetchers (removed earlier as "unused") — now consumed for map links; also added `website`/`address` from OSM tags.
- Coordinate order differs per provider (Gaia is lon/lat; CalTopo/PeakVisor lat/lon) — documented.
- 106 unit tests; Python verified live earlier.

## Agent context
- Contracts changed: hospital/ranger/campground entries gain `lat`,`lon`,`website`,`address` (optional). New report-writer + reviewer obligations (links, phone/address).
- Scope boundary: route-researcher SKILL.md, report-template.md, trip-report-template.md, docs/architecture.md, fetch_conditions.py (+tests). No release bump in this PR — cut separately as v5.1.0.
- Rollback risk: safe (additive; graceful degradation preserved).