### PR TITLE
chore(release): 5.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
         "url": "https://github.com/dreamiurg/claude-mountaineering-skills.git"
       },
       "description": "Automated mountain route research combining PeakBagger data, weather forecasts, avalanche conditions, and trip reports into comprehensive beta documents",
-      "version": "5.0.0"
+      "version": "5.1.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mountaineering",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Automated mountain route research combining PeakBagger data, weather forecasts, avalanche conditions, and trip reports into comprehensive beta documents",
   "author": {
     "name": "dreamiurg",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## [5.1.0](https://github.com/dreamiurg/claude-mountaineering-skills/compare/v5.0.0...v5.1.0) (2026-05-22)
+
+
+### Features
+
+* **route-researcher:** link CalTopo, Gaia GPS, and PeakVisor centered on the objective in the report Overview (US Topo removed) ([#81](https://github.com/dreamiurg/claude-mountaineering-skills/pull/81))
+* **route-researcher:** hyperlink every specific trip/climb-report attribution back to its source ([#81](https://github.com/dreamiurg/claude-mountaineering-skills/pull/81))
+* **route-researcher:** actively research current road/gate status (WSDOT, USFS forest alerts, NPS road pages, WTA, InciWeb) and report a dated status with sources, instead of telling the user to check ([#81](https://github.com/dreamiurg/claude-mountaineering-skills/pull/81))
+* **route-researcher:** emergency-contacts table now links each hospital/ranger to its website or Google Maps place and includes phone + address (geodata fetchers gained lat/lon/website/address); the Report Reviewer verifies these independently ([#81](https://github.com/dreamiurg/claude-mountaineering-skills/pull/81))
+* **route-researcher:** every named location (campsite, bivy, high camp, trailhead) is accompanied by Google Maps + Gaia GPS links ([#81](https://github.com/dreamiurg/claude-mountaineering-skills/pull/81))
+* **route-researcher:** trip-report template links the GitHub repository at the top ([#81](https://github.com/dreamiurg/claude-mountaineering-skills/pull/81))
+
+
+### Bug Fixes
+
+* **ci:** verify release scripts with `node --check` instead of running `--help` (which corrupted version files in the workspace) ([#80](https://github.com/dreamiurg/claude-mountaineering-skills/pull/80))
+
 ## [5.0.0](https://github.com/dreamiurg/claude-mountaineering-skills/compare/v4.0.2...v5.0.0) (2026-05-22)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mountaineering-skills",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Claude Code plugin for North American mountain route research",
   "private": true,
   "repository": {

--- a/skills/route-researcher/SKILL.md
+++ b/skills/route-researcher/SKILL.md
@@ -893,4 +893,4 @@ Example: `https://www.google.com/maps/search/?api=1&query=Cascade+Pass+Trailhead
 
 ---
 
-**Skill Version:** 5.0.0 | **Last Updated:** 2026-05-22
+**Skill Version:** 5.1.0 | **Last Updated:** 2026-05-22


### PR DESCRIPTION
Cuts **v5.1.0** (minor) for the report-linkification + road/gate-status feature batch (#81) and the CI verify fix (#80).

- Bumps `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `skills/route-researcher/SKILL.md` to 5.1.0 — the marketplace entry is bumped so `/plugin update mountaineering` serves the new version.
- Adds the 5.1.0 CHANGELOG entry.

Cut through the PR flow (semantic-release auto-push to main is blocked by branch protection); tag + GitHub Release created manually after merge.