### PR TITLE
chore: pin actions to SHAs, standardize README

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "ci(deps)"
     groups:
@@ -18,6 +20,8 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore(deps)"
     groups:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
       - run: pip install ruff
@@ -27,8 +27,8 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
       - name: Install uv
@@ -41,7 +41,7 @@ jobs:
     name: SAST
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Install Semgrep
         run: pip install semgrep
       - name: Run Semgrep
@@ -51,7 +51,7 @@ jobs:
     name: Validate Plugin
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - run: pip install check-jsonschema==0.31.3
       - name: Validate marketplace.json
         run: >-

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
         with:
           fail-on-severity: high
           comment-summary-in-pr: on-failure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
           ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 'lts/*'
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@
 
 Ask Claude to research any mountain. The route-researcher skill pulls from 10+ mountaineering sources and compiles a detailed Markdown report with current weather, avalanche conditions, daylight windows, trip reports, and route beta. What used to take 3-5 hours of tab-hopping now takes 3-5 minutes.
 
+> **Other projects you might like:** [PNW Climb Planner](https://dreamiurg.net/pnw-climb-planner.html) · [mountaineers-mcp](https://github.com/dreamiurg/mountaineers-mcp) · [mountaineers-assistant](https://github.com/dreamiurg/mountaineers-assistant) · [peakbagger-cli](https://github.com/dreamiurg/peakbagger-cli)
+
+<a href='https://ko-fi.com/Q3N622FHZM' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://storage.ko-fi.com/cdn/kofi5.png?v=6' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a>
+
 <p align="center">
   <img src="skills/route-researcher/assets/demo.gif" alt="Route Researcher Demo">
 </p>
@@ -222,16 +226,18 @@ Pull requests welcome. See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 [Open an issue](https://github.com/dreamiurg/claude-mountaineering-skills/issues) or [start a discussion](https://github.com/dreamiurg/claude-mountaineering-skills/discussions).
 
----
-
-## Other Mountaineering & Outdoors Tools
-
-I climb, scramble, and hike a lot, and I keep building tools around it. If this one's useful to you, the others might be too:
-
-- **[mountaineers-mcp](https://github.com/dreamiurg/mountaineers-mcp)** -- MCP server that lets AI assistants search and browse mountaineers.org. Activities, courses, trip reports, your account data. Works with Claude Desktop, Claude Code, and Codex CLI.
-- **[mountaineers-assistant](https://github.com/dreamiurg/mountaineers-assistant)** -- Chrome extension that syncs your mountaineers.org activity history and shows you stats, trends, and climbing partners you can't see on the site.
-- **[peakbagger-cli](https://github.com/dreamiurg/peakbagger-cli)** -- Command-line access to PeakBagger.com. Search peaks, check elevation and prominence, browse ascent stats. Outputs JSON for piping into other tools.
-
 ## License
 
 [MIT](LICENSE)
+
+---
+
+## More from @dreamiurg
+
+- 🏔️ **[PNW Climb Planner](https://dreamiurg.net/pnw-climb-planner.html)** — pick a Washington peak, see the odds of a climbable day from 20 years of weather data, and line up backups ([the story behind it](https://dreamiurg.net/2026/07/01/picking-backup-climbs.html))
+- **[mountaineers-mcp](https://github.com/dreamiurg/mountaineers-mcp)** — mountaineers.org for AI assistants: activities, courses, routes, trip reports
+- **[mountaineers-assistant](https://github.com/dreamiurg/mountaineers-assistant)** — Chrome extension with your Mountaineers climbing stats, local-only
+- **[peakbagger-cli](https://github.com/dreamiurg/peakbagger-cli)** — search and analyze PeakBagger.com peak data in your terminal
+- more at [dreamiurg.net/projects](https://dreamiurg.net/projects/)
+
+Made by [@dreamiurg](https://dreamiurg.net) in Seattle. If this project saved you time, you can [buy me a coffee](https://ko-fi.com/Q3N622FHZM) — appreciated, never expected.


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions in `ci.yml`, `dependabot-auto-merge.yml`, `dependency-review.yml`, and `release.yml` to full commit SHAs (with tag comments). This fixes the failing SAST check on main — semgrep's `--config auto` flags unpinned action tags.
- Standardize README: add "Other projects" header line + Ko-fi button after the intro, replace the old "Other Mountaineering & Outdoors Tools" section with the standardized "More from @dreamiurg" footer.

No badge removals: the two existing badges (Awesome Claude Code mention, Claude Code Plugin) are not in the removal categories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)