### PR TITLE
chore(plugin): add marketplace description and skills.sh badge

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,6 @@
 {
   "name": "mountaineering-marketplace",
+  "description": "Mountain route research skills for Claude Code — automated route beta reports for North American peaks with weather, avalanche conditions, and trip reports",
   "owner": {
     "name": "dreamiurg",
     "url": "https://github.com/dreamiurg"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "mountaineering-marketplace",
-  "description": "Mountain route research skills for Claude Code — automated route beta reports for North American peaks with weather, avalanche conditions, and trip reports",
+  "description": "Mountain route research for North American peaks",
   "owner": {
     "name": "dreamiurg",
     "url": "https://github.com/dreamiurg"

--- a/.claude-plugin/schemas/marketplace.schema.json
+++ b/.claude-plugin/schemas/marketplace.schema.json
@@ -3,7 +3,7 @@
   "title": "Claude Plugin Marketplace",
   "description": "Schema for .claude-plugin/marketplace.json",
   "type": "object",
-  "required": ["name", "owner", "plugins"],
+  "required": ["name", "description", "owner", "plugins"],
   "additionalProperties": false,
   "properties": {
     "name": {

--- a/.claude-plugin/schemas/marketplace.schema.json
+++ b/.claude-plugin/schemas/marketplace.schema.json
@@ -10,6 +10,10 @@
       "type": "string",
       "minLength": 1
     },
+    "description": {
+      "type": "string",
+      "minLength": 1
+    },
     "owner": {
       "type": "object",
       "required": ["name"],

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
   <a href="https://docs.anthropic.com/en/docs/claude-code/overview">
     <img src="https://img.shields.io/badge/Claude%20Code-Plugin-purple.svg" alt="Claude Code Plugin">
   </a>
+  <a href="https://skills.sh/dreamiurg/claude-mountaineering-skills">
+    <img src="https://skills.sh/b/dreamiurg/claude-mountaineering-skills" alt="skills.sh">
+  </a>
 </p>
 
 <h4 align="center">Automated mountain route research for North American peaks, built for <a href="https://claude.com/claude-code" target="_blank">Claude Code</a>.</h4>


### PR DESCRIPTION
Polish ahead of submitting the plugin to the Anthropic community marketplace:

- `.claude-plugin/marketplace.json`: add top-level `description` — closes the specific `claude plugin validate` warning about a missing marketplace description (note: a separate `--strict` warning about root CLAUDE.md remains and is out of scope here)
- `.claude-plugin/schemas/marketplace.schema.json`: allow the new `description` field (schema had `additionalProperties: false`) and add it to the top-level `required` array so the field can't silently regress
- README: add the skills.sh badge next to the existing badges (listing: https://skills.sh/dreamiurg/claude-mountaineering-skills)

No functional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
