### PR TITLE
feat: keyword-rich descriptions across plugin metadata

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "mountaineering-marketplace",
-  "description": "Mountain route research for North American peaks",
+  "description": "Mountain route research for North American peaks: automated route beta reports with weather forecasts, avalanche conditions, daylight windows, and trip reports aggregated from 10+ sources including PeakBagger, SummitPost, WTA, and AllTrails",
   "owner": {
     "name": "dreamiurg",
     "url": "https://github.com/dreamiurg"
@@ -12,7 +12,7 @@
         "source": "url",
         "url": "https://github.com/dreamiurg/claude-mountaineering-skills.git"
       },
-      "description": "Automated mountain route research combining PeakBagger data, weather forecasts, avalanche conditions, and trip reports into comprehensive beta documents",
+      "description": "Automated mountain route research for climbers, hikers, and mountaineers: aggregates PeakBagger, SummitPost, WTA, AllTrails, weather forecasts, and avalanche bulletins into comprehensive route beta reports for North American peaks",
       "version": "5.1.0"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mountaineering",
   "version": "5.1.0",
-  "description": "Automated mountain route research combining PeakBagger data, weather forecasts, avalanche conditions, and trip reports into comprehensive beta documents",
+  "description": "Automated mountain route research for climbers, hikers, and mountaineers: aggregates PeakBagger, SummitPost, WTA, AllTrails, weather forecasts, and avalanche bulletins into comprehensive route beta reports for North American peaks",
   "author": {
     "name": "dreamiurg",
     "email": "dreamiurg@users.noreply.github.com"

--- a/skills/route-researcher/SKILL.md
+++ b/skills/route-researcher/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: route-researcher
-description: Research North American mountain peaks and generate comprehensive route beta reports
+description: Research mountain routes and generate comprehensive route beta reports for North American peaks, aggregating weather forecasts, avalanche conditions, daylight windows, trip reports, and access info from PeakBagger, SummitPost, WTA, AllTrails, and regional avalanche centers. Use when planning a climb, hike, or scramble, or when asked for route beta, trail conditions, peak research, or mountaineering trip planning.
 ---
 
 # Route Researcher


### PR DESCRIPTION
Makes the plugin's descriptions comprehensive for discoverability ahead of the Anthropic community marketplace submission. Marketplaces and registries (skills.sh, SkillsMP, /plugin Discover, GitHub search) index these fields — the previous wording was minimal.

- `.claude-plugin/marketplace.json`: marketplace + plugin descriptions now name the aggregated sources (PeakBagger, SummitPost, WTA, AllTrails), audiences (climbers, hikers, mountaineers), and report contents (weather, avalanche, daylight, trip reports)
- `.claude-plugin/plugin.json`: same description, kept aligned with marketplace.json
- `skills/route-researcher/SKILL.md`: frontmatter description expanded with sources and 'Use when...' trigger phrases — this is what skills.sh displays and what Claude uses to decide when to activate the skill

Repo topics were also updated (claude-code, agent-skills, weather-forecast, avalanche, trip-planning, route-beta) — that's repo metadata, not part of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)